### PR TITLE
Ignore ssl certificate

### DIFF
--- a/Package Control.py
+++ b/Package Control.py
@@ -40,7 +40,7 @@ class PanelPrinter():
             self.window = sublime.active_window()
 
         if self.window != None:
-            self.panel  = self.window.get_output_panel(self.name)
+            self.panel = self.window.get_output_panel(self.name)
             self.panel.settings().set("word_wrap", True)
             self.write('Package Control Messages\n========================')
 
@@ -412,8 +412,11 @@ class WgetDownloader(CliDownloader):
         wget = self.find_binary('wget')
         if not wget:
             return False
-        command = [wget, '--no-check-certificate',  '--timeout', str(int(timeout)), '-o',
+        command = [wget, '--timeout', str(int(timeout)), '-o',
             '/dev/null', '-O', '-', '-U', 'Sublime Package Control', url]
+
+        if self.settings.get('ignore_ssl_certificates'):
+            command.append('--no-check-certificate')
 
         if self.settings.get('http_proxy'):
             os.putenv('http_proxy', self.settings.get('http_proxy'))
@@ -450,8 +453,11 @@ class CurlDownloader(CliDownloader):
         curl = self.find_binary('curl')
         if not curl:
             return False
-        command = [curl, '-k', '-f', '--user-agent', 'Sublime Package Control',
+        command = [curl, '-f', '--user-agent', 'Sublime Package Control',
             '--connect-timeout', str(int(timeout)), '-s', url]
+
+        if self.settings.get('ignore_ssl_certificates'):
+            command.append('-k')
 
         if self.settings.get('http_proxy'):
             os.putenv('http_proxy', self.settings.get('http_proxy'))

--- a/Package Control.sublime-settings
+++ b/Package Control.sublime-settings
@@ -39,6 +39,10 @@
 	// http_proxy is, http_proxy will be used for https_proxy also
 	"https_proxy": "",
 
+	// For some configurations, wget/curl ssl certficate check fail,
+	// causing the package control not to download all the available repositories
+	"ignore_ssl_certificates": false,
+
 	// Custom paths to VCS binaries for when they can't be automatically
 	// found on the system and a package includes a VCS metadata directory
 	"git_binary": "",


### PR DESCRIPTION
This little commit solves the issue where the https repositories could not be downloaded (at least on linux machines).
