### PR TITLE
Updated github api to list more than 30 repositories per user

### DIFF
--- a/Package Control.py
+++ b/Package Control.py
@@ -230,7 +230,7 @@ class GitHubUserProvider():
     def get_packages(self, url, package_manager):
         api_url = re.sub('^https?://github.com/',
             'https://api.github.com/users/', url)
-        api_url = api_url.rstrip('/') + '/repos'
+        api_url = api_url.rstrip('/') + '/repos?per_page=100'
         repo_json = package_manager.download_url(api_url,
             'Error downloading repository.')
         if repo_json == False:


### PR DESCRIPTION
Github API have a default limit of 30 itens per page when you request the repositories list. 

The @SublimeText organization have 37 at this moment, with this limit some repositories are not shown in the list. I updated this limit to 100 itens per page.
