### PR TITLE
Preventing a bad message from making a bad install.

### DIFF
--- a/Package Control.py
+++ b/Package Control.py
@@ -1465,7 +1465,7 @@ class PackageManager():
         try:
             self.print_messages(package_name, package_dir, is_upgrade, old_version)
         except (UnicodeDecodeError) as (e):
-            sublime.error_message(('%s: An error occurred while print update ' +
+            sublime.error_message(('%s: An error occurred while printing update ' +
                 'messages for %s. %s') %
                 (__name__, package_name, str(e)))
 


### PR DESCRIPTION
Ran into this during an install of latest SublimeLinter:

```
Exception in thread Thread-7:
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.6/lib/python2.6/threading.py", line 532, in __bootstrap_inner
    self.run()
  File "./Package Control.py", line 1871, in run
  File "./Package Control.py", line 1465, in install_package
  File "./Package Control.py", line 1533, in print_messages
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 3427: ordinal not in range(128)
```

Reduces the error to an ugly popup instead of breaking the install.
