### PR TITLE
Added support for GitHub/BitBucket sub-repos in 'packages.json' files

### DIFF
--- a/Package Control.py
+++ b/Package Control.py
@@ -257,6 +257,18 @@ class PackageProvider():
                 for download in package['platforms'][id]:
                     downloads.append(download)
 
+                version_orig = None
+                if 'version' in downloads[0]:
+                    version_orig = downloads[0]['version']
+
+                for provider_class in _single_package_providers:
+                    provider = provider_class(downloads[0]['url'], self.package_manager)
+                    if provider.match_url():
+                        downloads = provider.get_packages().popitem()[1]['downloads']
+
+                if version_orig != None:
+                    downloads[0]['version'] = version_orig
+
                 info = {
                     'name': package['name'],
                     'description': package.get('description'),
@@ -501,6 +513,8 @@ class BitBucketPackageProvider():
 
 _package_providers = [BitBucketPackageProvider, GitHubPackageProvider,
     GitHubUserProvider, PackageProvider]
+
+_single_package_providers = [BitBucketPackageProvider, GitHubPackageProvider]
 
 
 class BinaryNotFoundError(Exception):


### PR DESCRIPTION
- added optional use of GitHub or BitBucket single package providers as the source URL for individual packages within a generic package repository (packages.json)
- additionally, when using a GitHub or BitBucket package provider, 'version' becomes an optional parameter

RATIONALE: This modification adds an additional level of indirection which, if used while avoiding the optional 'version', allows for the creation of a more general 'packages.json' description file. This more generic 'packages.json' file would only need to be modified to add or remove package references; otherwise, it can remain unchanged while continuing to develop the individual packages.

In addition to the RATIONALE points, this set of modifications allows easier use of personal package forks (via the simpler 'packages.json' with decreased maintainence). And it helps avoid problematic repo base name collisions (as happens frequently when using a straight fork of a package for personal modifications). As the package names are set within 'packages.json', no 'package_name_map' is needed to accomplish the name disambiguation.

I was able to use this methodology to fork personal copies of a few Sublime Text packages and use them with the Package Manager simply by adding "https://raw.github.com/rivy/ST2.package-repo/master/packages.json" to "repositories" in the user settings.

For your evaluation...

Thanks for all the hard work getting this setup and working!

Roy Ivy III
