### PR TITLE
Better handle random github (or other repo) errors

### DIFF
--- a/Package Control.py
+++ b/Package Control.py
@@ -927,6 +927,10 @@ class UrlLib2Downloader(Downloader):
                 http_file = urllib2.urlopen(request, timeout=timeout)
                 return http_file.read()
 
+            except (httplib.HTTPException) as (e):
+                print '%s: %s HTTP exception %s (%s) downloading %s.' % (__name__,
+                    error_message, e.__class__.__name__, str(e), url)
+
             except (urllib2.HTTPError) as (e):
                 # Bitbucket and Github ratelimit using 503 a decent amount
                 if str(e.code) == '503':


### PR DESCRIPTION
A recent fileserver disruption at Github caused a few random package
repos to become unavailable. Part of the way they failed was to return
an HTTP status of 0. The httplib.HTTPException raised is not among (or
a parent of) the exceptions currently being caught, so this completely
broke attempts to install/upgrade packages.
