### PR TITLE
Github broke package tarball URLs, this is a temporary fix

### DIFF
--- a/Package Control.py
+++ b/Package Control.py
@@ -1806,7 +1806,7 @@ class PackageManager():
             return False
 
         timeout = self.settings.get('timeout', 3)
-        return downloader.download(url.replace(' ', '%20'), error_message,
+        return downloader.download(url.replace(' ', '%20').replace('zipball','legacy.zip'), error_message,
             timeout, 3)
 
     def get_metadata(self, package):


### PR DESCRIPTION
Package download urls need to be changed in several places to track the new github format of the day. Ideally, the download methods should all be modified to follow redirects, and the urls used should all be at api.github.com. This fix will get Package Control working in the meantime. 
