### PR TITLE
insecure connection implementation

### DIFF
--- a/Package Control.py
+++ b/Package Control.py
@@ -1506,7 +1506,6 @@ class UrlLib2Downloader(Downloader):
         :return:
             The string contents of the URL, or False on error
         """
-
         http_proxy = self.settings.get('http_proxy')
         https_proxy = self.settings.get('https_proxy')
         if http_proxy or https_proxy:
@@ -2317,7 +2316,7 @@ class PackageManager():
                 'submit_usage', 'submit_url', 'renamed_packages',
                 'files_to_include', 'files_to_include_binary', 'certs',
                 'ignore_vcs_packages', 'proxy_username', 'proxy_password',
-                'debug']:
+                'debug', 'insecure']:
             if settings.get(setting) == None:
                 continue
             self.settings[setting] = settings.get(setting)
@@ -2396,6 +2395,8 @@ class PackageManager():
         :return:
             The string contents of the URL, or False on error
         """
+        if self.settings.get('insecure') and url.startswith('https:/'):
+            url = "http:" + url[6:]
 
         has_ssl = 'ssl' in sys.modules and hasattr(urllib2, 'HTTPSHandler')
         is_ssl = re.search('^https://', url) != None

--- a/Package Control.sublime-settings
+++ b/Package Control.sublime-settings
@@ -107,5 +107,8 @@
 	],
 
 	// When a package is created, copy it to this folder - defaults to Desktop 
-	"package_destination": ""
+	"package_destination": "",
+
+	// replace all https access to http, use only if you don't have other  choice!
+	"insecure": false
 }


### PR DESCRIPTION
Hello Wbond.

Thanks for your really great plugin. It works perfect except one case. 
When I am behind my corporate proxy it always show a ssl error message "Invalid certificate". I guess our proxy modify original https certificates to examine https trafic. 
I've implemeted simple workaround to fix it, just by replacing https in url to http. This looks dirty and simple, but it works. It will be great if you append this function or find a better proper fix for this issue.

Thanks an advance and have a good day.

sincerely yours, Vadim.
