### PR TITLE
Fix bug with TypeError: 'str' does not support the buffer interface

### DIFF
--- a/package_control/http/validating_https_connection.py
+++ b/package_control/http/validating_https_connection.py
@@ -136,7 +136,7 @@ try:
             close_connection = False
             while True:
                 line = response.fp.readline()
-                if line == b'\r\n' or line == '\r\b':
+                if line == b'\r\n' or line == '\r\n':
                     break
 
                 if int(sublime.version()) > 3000:


### PR DESCRIPTION
Bug occurred when behind a corporate proxy,
confirmed on Windows XP, Windows 7, OS X 1.8.2

Credit goes to @holjan for the code

Fixes https://github.com/wbond/sublime_package_control/issues/310
