### PR TITLE
Version string in package-metadata.json causes crash.

### DIFF
--- a/package-metadata.json
+++ b/package-metadata.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.0.0-alpha2",
+	"version": "2.0.0.2",
 	"url": "http://wbond.net/sublime_packages/package_control",
 	"description": "A full-featured package manager"
 }


### PR DESCRIPTION
Attempting to install packages causes this error:

```
Traceback (most recent call last):
  File "X/threading.py", line 639, in _bootstrap_inner
  File "/Users/lxe/Library/Application Support/Sublime Text 3/Packages/Package Control/package_control/commands/install_package_command.py", line 42, in run
    'reinstall', 'pull', 'none'])
  File "/Users/lxe/Library/Application Support/Sublime Text 3/Packages/Package Control/package_control/package_installer.py", line 120, in make_package_list
    installed_version, download['version'])
  File "/Users/lxe/Library/Application Support/Sublime Text 3/Packages/Package Control/package_control/package_manager.py", line 147, in compare_versions
    cv1 = cmp_compat(version1)
  File "/Users/lxe/Library/Application Support/Sublime Text 3/Packages/Package Control/package_control/package_manager.py", line 140, in cmp_compat
    return [int(x) for x in re.sub(r'(\.0+)*$', '', v).split(".")]
  File "/Users/lxe/Library/Application Support/Sublime Text 3/Packages/Package Control/package_control/package_manager.py", line 140, in <listcomp>
    return [int(x) for x in re.sub(r'(\.0+)*$', '', v).split(".")]
ValueError: invalid literal for int() with base 10: '0-alpha2'
```

I changed the version string to 2.0.0.2. Either that or change the version parsing code. This was easier I think.
