### PR TITLE
ST3: Exclude the package "User" from package commands.

### DIFF
--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -439,7 +439,7 @@ class PackageManager():
             os.path.isdir(os.path.join(sublime.packages_path(), path))]
 
         # Ignore things to be deleted
-        ignored = []
+        ignored = ['User']
         for package in package_names:
             cleanup_file = os.path.join(sublime.packages_path(), package,
                 'package-control.cleanup')
@@ -457,6 +457,11 @@ class PackageManager():
 
         packages = os.listdir(sublime.packages_path())
         packages = sorted(packages, key=lambda s: s.lower())
+
+        # Exclude the "User" package which contains user settings
+        if 'User' in packages:
+            packages.remove('User')
+
         return packages
 
     def list_default_packages(self):


### PR DESCRIPTION
This pull request addresses issue #313 by excluding the `User` package from package commands.

As the `User` package contains user settings, it is probably not a good idea to be able to disable or remove it.
