### PR TITLE
Fix packages having no version causing crash

### DIFF
--- a/package_control/package_installer.py
+++ b/package_control/package_installer.py
@@ -72,7 +72,11 @@ class PackageInstaller():
 
             installed_version_name = 'v' + installed_version if \
                 installed and installed_version else 'unknown version'
-            new_version = 'v' + download['version']
+            if download.get('version'):
+                new_version = 'v' + download['version']
+            else:
+                """Don't show packages which don't have a version set"""
+                continue
 
             vcs = None
             package_dir = self.manager.get_package_dir(package)


### PR DESCRIPTION
Packages with no version set cause a KeyError in the make_package_list method. The change here intends to remove/hide packages with no version set in their package config, which would previously cause a KeyError.

See #410 for further information
