### PR TITLE
Testing Pythonic logging refactor.

### DIFF
--- a/package_control/automatic_upgrader.py
+++ b/package_control/automatic_upgrader.py
@@ -6,6 +6,8 @@ import time
 
 import sublime
 
+from . import logger
+log = logger.get(__name__)
 from .console_write import console_write
 from .package_installer import PackageInstaller
 from .package_renamer import PackageRenamer
@@ -25,7 +27,6 @@ class AutomaticUpgrader(threading.Thread):
             A list of package names for the packages that were found to be
             installed on the machine.
         """
-
         self.installer = PackageInstaller()
         self.manager = self.installer.manager
 
@@ -115,7 +116,8 @@ class AutomaticUpgrader(threading.Thread):
         date_format = '%Y-%m-%d %H:%M:%S'
         message_string = u'Skipping automatic upgrade, last run at %s, next run at %s or after' % (
             last_run.strftime(date_format), next_run.strftime(date_format))
-        console_write(message_string, True)
+        log.info(message_string)
+
 
     def upgrade_packages(self):
         """

--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -20,6 +20,7 @@ except (ImportError):
 
 import sublime
 
+from . import logger
 from .show_error import show_error
 from .console_write import console_write
 from .open_compat import open_compat, read_compat
@@ -71,6 +72,11 @@ class PackageManager():
                 continue
             self.settings[setting] = settings.get(setting)
 
+        # Initialize the global logger for the rest of program life.
+        debug = self.settings.get('debug')
+        logger.init(debug=debug)
+        log = logger.get(__name__)
+
         # https_proxy will inherit from http_proxy unless it is set to a
         # string value or false
         no_https_proxy = self.settings.get('https_proxy') in ["", None]
@@ -95,9 +101,10 @@ class PackageManager():
                 del filtered_settings[key]
 
         if filtered_settings != previous_settings and previous_settings != {}:
-            console_write(u'Settings change detected, clearing cache', True)
+            log.info(u'Settings change detected, clearing cache')
             clear_cache()
         set_cache('filtered_settings', filtered_settings)
+        log.debug("Package Manager initialized!")
 
     def get_metadata(self, package):
         """


### PR DESCRIPTION
Hello, I was looking over the shiny new code for ST3 and noticed it wasn't using Python's logging module. I did a partial implementation to see if this is something worth pursuing. 

The advantage here is that we can remove all the `if debug:` statements and we no longer have to pass a debug boolean around (`def read_package_file(package, relative_path, binary=False, debug=False):`).

Now we just need to stick a:

``` python
from . import logger
log = logger.get(__name__)
```

at the top of any module we want logging for.

Calling `log.debug(msg)` will only print when `debug: true` in the preferences file. Also, if debug is enabled we can print out extra info, like what module the log originated from.

It opens up a whole world of logging fun (http://docs.python.org/2.6/library/logging.html) as well, but the basics are good for now.

If this is something you want I'll go ahead and remove the `console_write` module and fully integrate the new logging mechanism then send another PR. 

Cheers!
