### PR TITLE
Add downloader option

### DIFF
--- a/Package Control.sublime-settings
+++ b/Package Control.sublime-settings
@@ -89,6 +89,10 @@
 	// User agent for HTTP requests
 	"user_agent": "Sublime Package Control",
 
+	// Set the package downloader (choose from urllib2, curl, or wget). Defaults
+	// to autodetect if null.
+	"downloader": null,
+
 	// Setting this to true will cause Package Control to ignore all git
 	// and hg repositories - this may help if trying to list packages to install
 	// hangs


### PR DESCRIPTION
For similar reasons to #467, this adds an option to manually specify which package downloader should be used. I need to provide some weird args to curl, but package control prefers urllib2, which is more difficult to configure. The default behavior is unchanged: use urllib2 if possible, otherwise curl if available, otherwise wget.
