### PR TITLE
Remove odd ^M trailing spaces

### DIFF
--- a/Package Control.sublime-settings
+++ b/Package Control.sublime-settings
@@ -1,138 +1,138 @@
 {
-	// A list of URLs that each contain a JSON file with a list of repositories.
-	// The repositories from these channels are placed in order after the
-	// repositories from the "repositories" setting
-	"repository_channels": [
-		"https://sublime.wbond.net/repositories.json"
-	],
-	
-	// A list of URLs that contain a packages JSON file. These repositories
-	// are placed in order before repositories from the "repository_channels"
-	// setting
-	"repositories": [],
+  // A list of URLs that each contain a JSON file with a list of repositories.
+  // The repositories from these channels are placed in order after the
+  // repositories from the "repositories" setting
+  "repository_channels": [
+    "https://sublime.wbond.net/repositories.json"
+  ],
 
-	// A list of CA certs needed for domains. The default channel provides a
-	// list of domains and an identifier (the md5 hash) for the CA cert(s)
-	// necessary for each.
-	//
-	// If a custom cert is required for a proxy or for an alternate channel
-	// or repository domain name, it should be added in one of the two forms:
-	//
-	// "*": ["my_identifier", "https://example.com/url/of/cert_file"]
-	// "*": ["my_identifier_2", "/absolute/filesystem/path/to/cert_file"]
-	//
-	// In both cases the literal "*" means the cert will be checked to ensure
-	// it is present for accessing any URL. This is necessary for proxy
-	// connections, but also useful if you want to provide you own
-	// ca-bundle.crt file.
-	//
-	// The "my_identifier" and "my_identifier_2" can be any unique string
-	// that Package Control can use as a filename, and ensures that it has
-	// merged the cert file with the ca-bundle.crt file in the certs/ directory
-	// since that is what is passed to the downloaders.
-	"certs": {
-		"api.bitbucket.org": ["d867a7b2aecc46f9c31afc4f2f50de05", ""],
-		"api.github.com": ["1c5282418e2cb4989cd6beddcdbab0b5", ""],
-		"bitbucket.org": ["897abe0b41fd2f64e9e2e351cbc36d76", ""],
-		"codeload.github.com": ["1c5282418e2cb4989cd6beddcdbab0b5", ""],
-		"raw.github.com": ["1c5282418e2cb4989cd6beddcdbab0b5", ""],
-		"sublime.wbond.net": ["7f4f8622b4fd001c7f648e09aae7edaa", ""]
-	},
+  // A list of URLs that contain a packages JSON file. These repositories
+  // are placed in order before repositories from the "repository_channels"
+  // setting
+  "repositories": [],
 
-	// If debugging information for HTTP/HTTPS connections should be printed
-	// to the Sublime Text console
-	"debug": false,
+  // A list of CA certs needed for domains. The default channel provides a
+  // list of domains and an identifier (the md5 hash) for the CA cert(s)
+  // necessary for each.
+  //
+  // If a custom cert is required for a proxy or for an alternate channel
+  // or repository domain name, it should be added in one of the two forms:
+  //
+  // "*": ["my_identifier", "https://example.com/url/of/cert_file"]
+  // "*": ["my_identifier_2", "/absolute/filesystem/path/to/cert_file"]
+  //
+  // In both cases the literal "*" means the cert will be checked to ensure
+  // it is present for accessing any URL. This is necessary for proxy
+  // connections, but also useful if you want to provide you own
+  // ca-bundle.crt file.
+  //
+  // The "my_identifier" and "my_identifier_2" can be any unique string
+  // that Package Control can use as a filename, and ensures that it has
+  // merged the cert file with the ca-bundle.crt file in the certs/ directory
+  // since that is what is passed to the downloaders.
+  "certs": {
+    "api.bitbucket.org": ["d867a7b2aecc46f9c31afc4f2f50de05", ""],
+    "api.github.com": ["1c5282418e2cb4989cd6beddcdbab0b5", ""],
+    "bitbucket.org": ["897abe0b41fd2f64e9e2e351cbc36d76", ""],
+    "codeload.github.com": ["1c5282418e2cb4989cd6beddcdbab0b5", ""],
+    "raw.github.com": ["1c5282418e2cb4989cd6beddcdbab0b5", ""],
+    "sublime.wbond.net": ["7f4f8622b4fd001c7f648e09aae7edaa", ""]
+  },
 
-	// This helps solve naming issues where a repository it not named the
-	// same as the package should be. This is primarily only useful for
-	// GitHub and BitBucket repositories. This mapping will override the
-	// mapping that is retrieved from the repository channels.
-	"package_name_map": {},
+  // If debugging information for HTTP/HTTPS connections should be printed
+  // to the Sublime Text console
+  "debug": false,
 
-	// If package install, upgrade and removal info should be submitted to
-	// the channel for aggregated statistics
-	"submit_usage": true,
+  // This helps solve naming issues where a repository it not named the
+  // same as the package should be. This is primarily only useful for
+  // GitHub and BitBucket repositories. This mapping will override the
+  // mapping that is retrieved from the repository channels.
+  "package_name_map": {},
 
-	// The URL to post install, upgrade and removal notices to 
-	"submit_url": "https://sublime.wbond.net/submit",
+  // If package install, upgrade and removal info should be submitted to
+  // the channel for aggregated statistics
+  "submit_usage": true,
 
-	// If packages should be automatically upgraded when ST2 starts
-	"auto_upgrade": true,
+  // The URL to post install, upgrade and removal notices to
+  "submit_url": "https://sublime.wbond.net/submit",
 
-	// If missing packages should be automatically installed when ST2 starts
-	"install_missing": true,
+  // If packages should be automatically upgraded when ST2 starts
+  "auto_upgrade": true,
 
-	// The minimum frequency in hours in which to check for automatic upgrades,
-	// setting this to 0 will always check for automatic upgrades
-	"auto_upgrade_frequency": 1,
+  // If missing packages should be automatically installed when ST2 starts
+  "install_missing": true,
 
-	// Packages to not auto upgrade
-	"auto_upgrade_ignore": [],
+  // The minimum frequency in hours in which to check for automatic upgrades,
+  // setting this to 0 will always check for automatic upgrades
+  "auto_upgrade_frequency": 1,
 
-	// Timeout for downloading channels, repositories and packages
-	"timeout": 30,
+  // Packages to not auto upgrade
+  "auto_upgrade_ignore": [],
 
-	// The number of seconds to cache repository and package info for
-	"cache_length": 300,
+  // Timeout for downloading channels, repositories and packages
+  "timeout": 30,
 
-	// An HTTP proxy server to use for requests
-	"http_proxy": "",
-	// An HTTPS proxy server to use for requests - this will inherit from
-	// http_proxy if it is set to "" or null and http_proxy has a value. You
-	// can set this to false to prevent inheriting from http_proxy.
-	"https_proxy": "",
+  // The number of seconds to cache repository and package info for
+  "cache_length": 300,
 
-	// Username and password for both http_proxy and https_proxy
-	"proxy_username": "",
-	"proxy_password": "",
+  // An HTTP proxy server to use for requests
+  "http_proxy": "",
+  // An HTTPS proxy server to use for requests - this will inherit from
+  // http_proxy if it is set to "" or null and http_proxy has a value. You
+  // can set this to false to prevent inheriting from http_proxy.
+  "https_proxy": "",
 
-	// User agent for HTTP requests
-	"user_agent": "Sublime Package Control",
+  // Username and password for both http_proxy and https_proxy
+  "proxy_username": "",
+  "proxy_password": "",
 
-	// Setting this to true will cause Package Control to ignore all git
-	// and hg repositories - this may help if trying to list packages to install
-	// hangs
-	"ignore_vcs_packages": false,
+  // User agent for HTTP requests
+  "user_agent": "Sublime Package Control",
 
-	// Custom paths to VCS binaries for when they can't be automatically
-	// found on the system and a package includes a VCS metadata directory
-	"git_binary": "",
-	"git_update_command": ["pull", "origin", "master", "--ff", "--commit"],
-	
-	"hg_binary": "",
-	
-	// Be sure to keep the remote name as the last argument
-	"hg_update_command": ["pull", "--update", "default"],
+  // Setting this to true will cause Package Control to ignore all git
+  // and hg repositories - this may help if trying to list packages to install
+  // hangs
+  "ignore_vcs_packages": false,
 
-	// Directories to ignore when creating a package
-	"dirs_to_ignore": [
-		".hg", ".git", ".svn", "_darcs", "CVS"
-	],
+  // Custom paths to VCS binaries for when they can't be automatically
+  // found on the system and a package includes a VCS metadata directory
+  "git_binary": "",
+  "git_update_command": ["pull", "origin", "master", "--ff", "--commit"],
 
-	// Files to ignore when creating a package
-	"files_to_ignore": [
-		".hgignore", ".gitignore", ".bzrignore", "*.pyc", "*.sublime-project",
-		"*.sublime-workspace", "*.tmTheme.cache"
-	],
+  "hg_binary": "",
 
-	// Files to include, even if they match a pattern in files_to_ignore
-	"files_to_include": [],
+  // Be sure to keep the remote name as the last argument
+  "hg_update_command": ["pull", "--update", "default"],
 
-	// Files to ignore when creating a binary package. By default binary
-	// packages ship with .pyc files instead of .py files. If an __init__.py
-	// file exists, it will always be included, even if it matches one of
-	// these patterns.
-	"files_to_ignore_binary": [
-		".hgignore", ".gitignore", ".bzrignore", "*.py", "*.sublime-project",
-		"*.sublime-workspace", "*.tmTheme.cache"
-	],
+  // Directories to ignore when creating a package
+  "dirs_to_ignore": [
+    ".hg", ".git", ".svn", "_darcs", "CVS"
+  ],
 
-	// Files to include for a binary package, even if they match a pattern i
-	// files_to_ignore_binary
-	"files_to_include_binary": [
-		"__init__.py"
-	],
+  // Files to ignore when creating a package
+  "files_to_ignore": [
+    ".hgignore", ".gitignore", ".bzrignore", "*.pyc", "*.sublime-project",
+    "*.sublime-workspace", "*.tmTheme.cache"
+  ],
 
-	// When a package is created, copy it to this folder - defaults to Desktop 
-	"package_destination": ""
+  // Files to include, even if they match a pattern in files_to_ignore
+  "files_to_include": [],
+
+  // Files to ignore when creating a binary package. By default binary
+  // packages ship with .pyc files instead of .py files. If an __init__.py
+  // file exists, it will always be included, even if it matches one of
+  // these patterns.
+  "files_to_ignore_binary": [
+    ".hgignore", ".gitignore", ".bzrignore", "*.py", "*.sublime-project",
+    "*.sublime-workspace", "*.tmTheme.cache"
+  ],
+
+  // Files to include for a binary package, even if they match a pattern i
+  // files_to_ignore_binary
+  "files_to_include_binary": [
+    "__init__.py"
+  ],
+
+  // When a package is created, copy it to this folder - defaults to Desktop
+  "package_destination": ""
 }


### PR DESCRIPTION
This change is to remove trailing ^M characters in Package Control.sublime-settings. EOM

To see these trailing spaces

$ cat -ve Package\ Control.sublime-settings 
