### PR TITLE
fix package_manager.py non-ASCII problem

### DIFF
--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -465,7 +465,7 @@ class PackageManager():
         url = packages[package_name]['download']['url']
         package_filename = package_name + '.sublime-package'
 
-        tmp_dir = tempfile.mkdtemp()
+        tmp_dir = tempfile.mkdtemp(u'')
 
         try:
             # This is refers to the zipfile later on, so we define it here so we can


### PR DESCRIPTION
While install new package on Win7 with login account named in CJK, I can't install package. The error in Sublime console was:

```
Traceback (most recent call last):
  File ".\threading.py", line 532, in __bootstrap_inner
  File ".\package_control\package_installer.py", line 244, in run
  File ".\package_control\package_manager.py", line 476, in install_package
  File ".\ntpath.py", line 108, in join
UnicodeDecodeError: 'ascii' codec can't decode byte 0xcd in position 9: ordinal not in range(128)

ignored packages updated to: [Vintage]
```

So I figuered out that the file path will throw an unicode exception since the `package_name` variable was unicode fron JSON all the way down . This patch fixes the problem and the path will be str().
