### PR TITLE
Improved cleanup if file is in use.

### DIFF
--- a/package_control/clear_directory.py
+++ b/package_control/clear_directory.py
@@ -30,7 +30,13 @@ def clear_directory(directory, ignore_paths=None):
                 if os.path.isdir(path):
                     os.rmdir(path)
                 else:
-                    os.remove(path)
+                    try:
+                        os.remove(path)
+                    except OSError:
+                        # try to rename file to reduce chance that
+                        # file is in use on next start
+                        os.rename(path, path + '.old')
+                        raise
             except (OSError, IOError):
                 was_exception = True
 

--- a/package_control/rmtree.py
+++ b/package_control/rmtree.py
@@ -3,7 +3,6 @@ import shutil
 import stat
 
 
-
 def _on_error(function, path, excinfo):
     """
     Error handler for shutil.rmtree that tries to add write privileges
@@ -21,6 +20,9 @@ def _on_error(function, path, excinfo):
         os.chmod(path, stat.S_IWUSR)
         function(path)
     else:
+        # try to rename file to reduce chance that
+        # file is in use on next start
+        os.rename(path, path + '.old')
         raise
 
 


### PR DESCRIPTION
If a file from a package is in use by another package, there is currently no way to remove it because it will always be in use, even after restarting Sublime or the computer. 

However, on Windows you are usually able to rename the file even if it is in use. As consequence, these renamed files won't be in use after a restart and package control is able to delete the directory.
