### PR TITLE
Added command to list installed packages not managed by Package Control.

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -36,6 +36,10 @@
         "command": "list_packages"
     },
     {
+        "caption": "Package Control: List Unmanaged Packages",
+        "command": "list_unmanaged_packages"
+    },
+    {
         "caption": "Package Control: Remove Package",
         "command": "remove_package"
     },

--- a/Package Control.sublime-settings
+++ b/Package Control.sublime-settings
@@ -132,6 +132,9 @@
 	// only used when running the Grab CA Certs command.
 	"openssl_binary": "",
 
+	// Additional packages to ignore when listing unmanaged packages.
+	"unmanaged_packages_ignore": ["Package Control"],
+
 	// Directories to ignore when creating a package
 	"dirs_to_ignore": [
 		".hg", ".git", ".svn", "_darcs", "CVS"

--- a/package_control/commands/__init__.py
+++ b/package_control/commands/__init__.py
@@ -9,6 +9,7 @@ from .enable_package_command import EnablePackageCommand
 from .grab_certs_command import GrabCertsCommand
 from .install_package_command import InstallPackageCommand
 from .list_packages_command import ListPackagesCommand
+from .list_unmanaged_packages_command import ListUnmanagedPackagesCommand
 from .remove_package_command import RemovePackageCommand
 from .upgrade_all_packages_command import UpgradeAllPackagesCommand
 from .upgrade_package_command import UpgradePackageCommand
@@ -24,6 +25,7 @@ __all__ = [
     'EnablePackageCommand',
     'InstallPackageCommand',
     'ListPackagesCommand',
+    'ListUnmanagedPackagesCommand',
     'RemovePackageCommand',
     'UpgradeAllPackagesCommand',
     'UpgradePackageCommand',

--- a/package_control/commands/list_packages_command.py
+++ b/package_control/commands/list_packages_command.py
@@ -22,19 +22,32 @@ class ListPackagesThread(threading.Thread, ExistingPackagesCommand):
     A thread to prevent the listing of existing packages from freezing the UI
     """
 
-    def __init__(self, window):
+    def __init__(self, window, filter_function=None):
         """
         :param window:
             An instance of :class:`sublime.Window` that represents the Sublime
             Text window to show the list of installed packages in.
+        :param filter_function:
+            A callable to filter packages for display. This function gets
+            called for each package in the list with a three-element list
+            as returned by :meth:`ExistingPackagesCommand.make_package_list`:
+              0 - package name
+              1 - package description
+              2 - [action] installed version; package url
+            If the function returns a true value, the package is listed,
+            otherwise it is discarded. If `None`, no filtering is performed.
         """
 
         self.window = window
+        self.filter_function = filter_function
         threading.Thread.__init__(self)
         ExistingPackagesCommand.__init__(self)
 
     def run(self):
         self.package_list = self.make_package_list()
+        if self.filter_function:
+            self.package_list = list(filter(self.filter_function,
+                                            self.package_list))
 
         def show_quick_panel():
             if not self.package_list:

--- a/package_control/commands/list_unmanaged_packages_command.py
+++ b/package_control/commands/list_unmanaged_packages_command.py
@@ -1,0 +1,22 @@
+import sublime
+import sublime_plugin
+
+from .list_packages_command import ListPackagesThread
+
+
+class ListUnmanagedPackagesCommand(sublime_plugin.WindowCommand):
+    """
+    A command that shows a list of all packages that are not managed by
+    Package Control, i.e. that are installed, but not mentioned in
+    `installed_packages`.
+    """
+
+    def run(self):
+        settings = sublime.load_settings('Package Control.sublime-settings')
+        ignored_packages = []
+        ignored_packages.extend(settings.get('unmanaged_packages_ignore', []))
+        ignored_packages.extend(settings.get('installed_packages', []))
+        ListPackagesThread(
+            self.window,
+            lambda package: package[0] not in ignored_packages,
+        ).start()


### PR DESCRIPTION
As promised, here's the "stray package listing" directly for Package Control; I've re-styled it to more closely match the existing "List Packages" command now.

(Still a bit unhappy with the name of the setting though...)
