### PR TITLE
Read SSL_CERT_FILE environment variable to get ca-certs on Linux

### DIFF
--- a/package_control/ca_certs.py
+++ b/package_control/ca_certs.py
@@ -146,20 +146,24 @@ def get_system_ca_bundle_path(settings):
 
     # Linux
     else:
-        # Common CA cert paths
-        paths = [
-            '/usr/lib/ssl/certs/ca-certificates.crt',
-            '/etc/ssl/certs/ca-certificates.crt',
-            '/etc/ssl/certs/ca-bundle.crt',
-            '/etc/pki/tls/certs/ca-bundle.crt',
-            '/etc/ssl/ca-bundle.pem',
-            '/usr/local/share/certs/ca-root-nss.crt',
-            '/etc/ssl/cert.pem'
-        ]
-        for path in paths:
-            if os.path.exists(path) and os.path.getsize(path) > 0:
-                ca_path = path
-                break
+        # Check for SSL_CERT_FILE variable
+        if 'SSL_CERT_FILE' in os.environ:
+            ca_path = os.environ['SSL_CERT_FILE']
+        else:
+            # Common CA cert paths
+            paths = [
+                '/usr/lib/ssl/certs/ca-certificates.crt',
+                '/etc/ssl/certs/ca-certificates.crt',
+                '/etc/ssl/certs/ca-bundle.crt',
+                '/etc/pki/tls/certs/ca-bundle.crt',
+                '/etc/ssl/ca-bundle.pem',
+                '/usr/local/share/certs/ca-root-nss.crt',
+                '/etc/ssl/cert.pem'
+            ]
+            for path in paths:
+                if os.path.exists(path) and os.path.getsize(path) > 0:
+                    ca_path = path
+                    break
 
         if debug and ca_path:
             console_write(u"Found system CA bundle at %s" % ca_path, True)


### PR DESCRIPTION
This should fix Package Control on NixOS, and also is a more standards-compliant way of searching for ca-certs.

I'm not really using Sublime so I haven't tested this -- the patch looks good for me and is simple enough though.
