### PR TITLE
fix an encode problem on the Windows

### DIFF
--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -490,7 +490,7 @@ class PackageManager():
         url = packages[package_name]['download']['url']
         package_filename = package_name + '.sublime-package'
 
-        tmp_dir = tempfile.mkdtemp(u'')
+        tmp_dir = tempfile.mkdtemp().decode(sys.getfilesystemencoding())
 
         try:
             # This is refers to the zipfile later on, so we define it here so we can


### PR DESCRIPTION
I found tempfile.mkdtemp(u'') still be error on the Windows 8.1 with Chinese language.
After I search the python source, found that "tempfile.mkdtemp" use "os.getenv" to get temp path. "os.getenv" get an GBK encoded string on my computer. 
I try to use tempfile.mkdtemp().decode(sys.getfilesystemencoding()) , then find it's work fine.
