### PR TITLE
Rework (debug) output when installing dependency

### DIFF
--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -1100,7 +1100,7 @@ class PackageManager():
             dependency_hg_dir = os.path.join(dependency_dir, '.hg')
             dependency_metadata = self.get_metadata(dependency, is_dependency=True) or {}
 
-            dependency_releases = packages.get('dependency', {}).get('releases', [])
+            dependency_releases = packages.get(dependency, {}).get('releases', [])
             dependency_release = dependency_releases[0] if dependency_releases else {}
 
             installed_version = dependency_metadata.get('version')
@@ -1119,7 +1119,7 @@ class PackageManager():
 
             def dependency_write_debug(msg):
                 if debug:
-                    dependency_write(debug)
+                    dependency_write(msg)
 
             install_dependency = False
             if not os.path.exists(dependency_dir):

--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -1101,7 +1101,7 @@ class PackageManager():
             dependency_metadata = self.get_metadata(dependency, is_dependency=True) or {}
 
             dependency_releases = packages.get('dependency', {}).get('releases', [])
-            dependency_release = dependency_releases[0] if dependency_releases else []
+            dependency_release = dependency_releases[0] if dependency_releases else {}
 
             installed_version = dependency_metadata.get('version')
             installed_version = version_comparable(installed_version) if installed_version else None


### PR DESCRIPTION
I initially just wanted to solve #827 but then I discovered that the code is actually there, just gated by the `debug` setting. So I changed the scope of some output messages (debug vs always) and then created a convenience output function because of the amount of reoccuring code. I also added more diverse messages for certain situations.

I did not actually test this because it's somewhat hard to emulate the environment, but I went over the code like three times to check if there were errors.

Closes #827.