### PR TITLE
Manually "reload" loader code when added to zip

### DIFF
--- a/package_control/loader.py
+++ b/package_control/loader.py
@@ -186,6 +186,12 @@ def remove(name):
     disabler = PackageDisabler()
     disabler.disable_package(loader_package_name)
 
+    # Note: If we "manually" loaded the dependency loader before it will not
+    # be unloaded automatically when the package is disabled. Since it is
+    # highly doubtful that anyone would define `plugin_unloaded` in his
+    # `loader.py`, we don't necessarily have to implement it, but this is just
+    # a note.
+
     def do_swap():
         os.remove(loader_package_path)
         os.rename(new_loader_package_path, loader_package_path)

--- a/package_control/loader.py
+++ b/package_control/loader.py
@@ -13,6 +13,7 @@ except (NameError):
     str_cls = str
 
 import sublime
+import sublime_plugin
 
 from .sys_path import st_dir
 from .console_write import console_write
@@ -88,6 +89,11 @@ def add(priority, name, code=None):
                 just_created_loader = True
                 z.writestr('dependency-metadata.json', loader_metadata_enc)
             z.writestr(loader_filename, code.encode('utf-8'))
+
+        if not just_created_loader:
+            # Manually execute the loader code because Sublime Text does not
+            # detect changes to the zip archive, only if the file is new.
+            sublime_plugin.reload_plugin("%s.%s" % (loader_package_name, loader_filename[:-3]))
 
     # Clean things up for people who were tracking the master branch
     if just_created_loader:


### PR DESCRIPTION
I'm kind of surprised this actually works, assuming the zip file was edited just before that, but it does. On Windows at least.

Closes #821.