### PR TITLE
Make removing dependencies work

### DIFF
--- a/package_control/loader.py
+++ b/package_control/loader.py
@@ -178,10 +178,10 @@ def remove(name):
         return
 
     disabler = PackageDisabler()
-    disabler.disable_packages(loader_package_name, '')
+    disabler.disable_packages(loader_package_name, 'loader')
 
     def do_swap():
         os.remove(loader_package_path)
         os.rename(new_loader_package_path, loader_package_path)
-        sublime.set_timeout(lambda: disabler.reenable_package(loader_package_name, ''), 10)
+        sublime.set_timeout(lambda: disabler.reenable_package(loader_package_name, 'loader'), 10)
     sublime.set_timeout(do_swap, 700)

--- a/package_control/loader.py
+++ b/package_control/loader.py
@@ -178,10 +178,10 @@ def remove(name):
         return
 
     disabler = PackageDisabler()
-    disabler.disable_package(loader_package_name)
+    disabler.disable_packages(loader_package_name, '')
 
     def do_swap():
         os.remove(loader_package_path)
         os.rename(new_loader_package_path, loader_package_path)
-        sublime.set_timeout(lambda: disabler.reenable_package(loader_package_name), 10)
+        sublime.set_timeout(lambda: disabler.reenable_package(loader_package_name, ''), 10)
     sublime.set_timeout(do_swap, 700)

--- a/package_control/package_disabler.py
+++ b/package_control/package_disabler.py
@@ -50,6 +50,7 @@ class PackageDisabler():
              - "remove"
              - "install"
              - "disable"
+             - "loader"
         """
 
         if not isinstance(packages, list):
@@ -126,6 +127,7 @@ class PackageDisabler():
              - "remove"
              - "install"
              - "enable"
+             - "loader"
         """
 
         settings = sublime.load_settings(preferences_filename())


### PR DESCRIPTION
Fixes #820.

Empty second parameter was added because this is not your ordinary package and we don't need events for it.