### PR TITLE
Don't ignore `dependencies.json` on pkg install

### DIFF
--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -710,9 +710,10 @@ class PackageManager():
         have_installed_dependencies = False
         if not is_dependency:
             dependencies = release.get('dependencies', [])
-            if not self.install_dependencies(dependencies):
-                return False
-            have_installed_dependencies = True
+            if dependencies:
+                if not self.install_dependencies(dependencies):
+                    return False
+                have_installed_dependencies = True
 
         url = release['url']
         package_filename = package_name + '.sublime-package'


### PR DESCRIPTION
I have no idea why I only noticed this when I tried on ST2, but for some reason this worked on ST3 before, even though it shouldn't have. Funnily it stopped working once I noticed where the problem was and added some debug prints.