### PR TITLE
Cleanup dependencies in Satisfy Command

### DIFF
--- a/package_control/commands/satisfy_dependencies_command.py
+++ b/package_control/commands/satisfy_dependencies_command.py
@@ -39,7 +39,7 @@ class SatisfyDependenciesThread(threading.Thread):
     def run(self):
         required_dependencies = self.manager.find_required_dependencies()
 
-        if not self.manager.install_dependencies(required_dependencies):
+        if not self.manager.install_dependencies(required_dependencies, fail_early=False):
             self.show_error(u'One or more dependencies could not be installed '
                             'or updated. Please check the console for details.')
 

--- a/package_control/commands/satisfy_dependencies_command.py
+++ b/package_control/commands/satisfy_dependencies_command.py
@@ -3,6 +3,8 @@ import threading
 import sublime
 import sublime_plugin
 
+from functools import partial
+
 from ..show_error import show_error
 from ..package_manager import PackageManager
 from ..thread_progress import ThreadProgress
@@ -31,12 +33,16 @@ class SatisfyDependenciesThread(threading.Thread):
         self.manager = manager
         threading.Thread.__init__(self)
 
+    def show_error(msg):
+        sublime.set_timeout(partial(show_error, msg), 10)
+
     def run(self):
-        dependencies = self.manager.find_required_dependencies()
-        result = self.manager.install_dependencies(dependencies)
-        if not result:
-            def do_show_error():
-                show_error(u'One or more dependencies could not be ' + \
-                    'installed or updated. Please check the console for ' + \
-                    'details.')
-            sublime.set_timeout(do_show_error, 10)
+        required_dependencies = self.manager.find_required_dependencies()
+
+        if not self.manager.install_dependencies(required_dependencies):
+            self.show_error(u'One or more dependencies could not be installed '
+                            'or updated. Please check the console for details.')
+
+        if not self.manager.cleanup_dependencies(required_dependencies=required_dependencies):
+            self.show_error(u'One or more orphaned dependencies could not be '
+                            'removed. Please check the console for details.')

--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -1137,6 +1137,42 @@ class PackageManager():
 
         return True
 
+    def cleanup_dependencies(self, ignore_package=None, installed_dependencies=None, required_dependencies=None):
+        """
+        Remove all not needed dependencies by the installed packages,
+        ignoring the specified package.
+
+        :param ignore_package:
+            The package to ignore when enumerating dependencies.
+            Not used when required_dependencies is provided.
+
+        :param installed_dependencies:
+            All installed dependencies, for speedup purposes.
+
+        :param required_dependencies:
+            All required dependencies, for speedup purposes.
+
+        :return:
+            Boolean indicating the success of the removals.
+        """
+
+        if not installed_dependencies:
+            installed_dependencies = self.list_dependencies()
+        if not required_dependencies:
+            required_dependencies = self.find_required_dependencies(ignore_package)
+
+        orphaned_dependencies = set(installed_dependencies) - set(required_dependencies)
+        orphaned_dependencies = sorted(orphaned_dependencies, key=lambda s: s.lower())
+
+        error = False
+        for dependency in orphaned_dependencies:
+            if self.remove_package(dependency, is_dependency=True):
+                console_write(u"The orphaned dependency %s has been removed" % dependency, True)
+            else:
+                error = True
+
+        return not error
+
     def backup_package_dir(self, package_name):
         """
         Does a full backup of the Packages/{package}/ dir to Backup/
@@ -1388,12 +1424,7 @@ class PackageManager():
             console_write(u"The package %s has been removed" % package_name + clean_up, True)
 
             # Remove dependencies that are no longer needed
-            installed_dependencies = self.list_dependencies()
-            required_dependencies = self.find_required_dependencies(package_name)
-            orphaned_dependencies = list(set(installed_dependencies) - set(required_dependencies))
-            for dependency in orphaned_dependencies:
-                if self.remove_package(dependency, is_dependency=True):
-                    console_write(u"The orphaned dependency %s has been removed" % dependency, True)
+            self.cleanup_dependencies(package_name)
 
         return True
 

--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -1075,7 +1075,7 @@ class PackageManager():
             # after we close it.
             sublime.set_timeout(lambda: delete_directory(tmp_dir), 1000)
 
-    def install_dependencies(self, dependencies):
+    def install_dependencies(self, dependencies, fail_early=True):
         """
         Ensures a list of dependencies are installed and up-to-date
 
@@ -1090,6 +1090,7 @@ class PackageManager():
 
         packages = self.list_available_packages(exclude_dependencies=False)
 
+        error = False
         for dependency in dependencies:
             # This is a per-machine dynamically created dependency, so we skip
             if dependency == '0_package_control_loader':
@@ -1131,11 +1132,12 @@ class PackageManager():
                         console_write(u'The dependency %s is installed and up-to-date, leaving alone' % dependency, True)
 
             if install_dependency:
-                dependency_result = self.install_package(dependency, True)
-                if not dependency_result:
-                    return dependency_result
+                if not self.install_package(dependency, True):
+                    if fail_early:
+                        return False
+                    error = True
 
-        return True
+        return not error
 
     def cleanup_dependencies(self, ignore_package=None, installed_dependencies=None, required_dependencies=None):
         """

--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -1384,7 +1384,8 @@ class PackageManager():
             loader.remove(package_name)
 
         else:
-            console_write(u"The package %s has been removed" % package_name, True)
+            clean_up = " and will be cleaned up on the next restart" if not can_delete_dir else ''
+            console_write(u"The package %s has been removed" % package_name + clean_up, True)
 
             # Remove dependencies that are no longer needed
             installed_dependencies = self.list_dependencies()

--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -1384,12 +1384,15 @@ class PackageManager():
             loader.remove(package_name)
 
         else:
+            console_write(u"The package %s has been removed" % package_name, True)
+
             # Remove dependencies that are no longer needed
             installed_dependencies = self.list_dependencies()
             required_dependencies = self.find_required_dependencies(package_name)
             orphaned_dependencies = list(set(installed_dependencies) - set(required_dependencies))
             for dependency in orphaned_dependencies:
-                self.remove_package(dependency, is_dependency=True)
+                if self.remove_package(dependency, is_dependency=True):
+                    console_write(u"The orphaned dependency %s has been removed" % dependency, True)
 
         return True
 


### PR DESCRIPTION
I also considered adding this functionality to `AutomaticUpdater.install_missing` but wasn't sure what the right place would be and whether I should create a new method for it since it has technically a different functionality than what the name suggests.

This PR supersedes #841 and includes all its commits. Closes #839, I suppose.

Will probably add automatic removal to the auto updater this evening or tomorrow, unless you have any objections.