### PR TITLE
Don't re-enable package when operation is deferred until next restart

### DIFF
--- a/package_control/automatic_upgrader.py
+++ b/package_control/automatic_upgrader.py
@@ -3,6 +3,7 @@ import re
 import os
 import datetime
 import time
+import functools
 
 import sublime
 
@@ -237,15 +238,9 @@ class AutomaticUpgrader(threading.Thread):
             # Wait so that the ignored packages can be "unloaded"
             time.sleep(0.7)
 
-            # We use a function to generate the on-complete lambda because if
-            # we don't, the lambda will bind to info at the current scope, and
-            # thus use the last value of info from the loop
-            def make_on_complete(name):
-                return lambda: self.installer.reenable_package(name)
-
             for info in package_list:
                 if info[0] in disabled_packages:
-                    on_complete = make_on_complete(info[0])
+                    on_complete = functools.partial(self.installer.reenable_package, info[0])
                 else:
                     on_complete = None
 

--- a/package_control/automatic_upgrader.py
+++ b/package_control/automatic_upgrader.py
@@ -240,6 +240,8 @@ class AutomaticUpgrader(threading.Thread):
 
             for info in package_list:
                 if info[0] in disabled_packages:
+                    # We use a functools.partial to generate the on-complete callback in
+                    # order to bind the current value of the parameters, unlike lambdas.
                     on_complete = functools.partial(self.installer.reenable_package, info[0])
                 else:
                     on_complete = None

--- a/package_control/commands/advanced_install_package_command.py
+++ b/package_control/commands/advanced_install_package_command.py
@@ -101,4 +101,6 @@ class AdvancedInstallPackageThread(threading.Thread, PackageDisabler):
 
             # Do not reenable if installation deferred until next restart
             if result is not None:
+                # We use a functools.partial to generate the on-complete callback in
+                # order to bind the current value of the parameters, unlike lambdas.
                 sublime.set_timeout(functools.partial(do_reenable_package, package), 700)

--- a/package_control/commands/advanced_install_package_command.py
+++ b/package_control/commands/advanced_install_package_command.py
@@ -92,7 +92,10 @@ class AdvancedInstallPackageThread(threading.Thread, PackageDisabler):
         time.sleep(0.7)
 
         for package in self.packages:
-            self.manager.install_package(package)
+            result = self.manager.install_package(package)
+            # Do not reenable if installation deferred until next restart
+            if result is None:
+                continue
 
             # We use a wrapper function since this call is in a loop, so
             # directly using the "package" variable would cause the value to

--- a/package_control/commands/remove_package_command.py
+++ b/package_control/commands/remove_package_command.py
@@ -72,6 +72,9 @@ class RemovePackageThread(threading.Thread, PackageDisabler):
         time.sleep(0.7)
         self.result = self.manager.remove_package(self.package)
 
-        def unignore_package():
-            self.reenable_package(self.package, 'remove')
-        sublime.set_timeout(unignore_package, 200)
+        # Do not reenable if removing deferred until next restart
+        if self.result is not None:
+            def unignore_package():
+                    self.reenable_package(self.package, 'remove')
+
+            sublime.set_timeout(unignore_package, 200)

--- a/package_control/commands/satisfy_dependencies_command.py
+++ b/package_control/commands/satisfy_dependencies_command.py
@@ -3,7 +3,7 @@ import threading
 import sublime
 import sublime_plugin
 
-from functools import partial
+import functools
 
 from ..show_error import show_error
 from ..package_manager import PackageManager
@@ -34,7 +34,7 @@ class SatisfyDependenciesThread(threading.Thread):
         threading.Thread.__init__(self)
 
     def show_error(msg):
-        sublime.set_timeout(partial(show_error, msg), 10)
+        sublime.set_timeout(functools.partial(show_error, msg), 10)
 
     def run(self):
         required_dependencies = self.manager.find_required_dependencies()

--- a/package_control/commands/upgrade_all_packages_command.py
+++ b/package_control/commands/upgrade_all_packages_command.py
@@ -1,5 +1,6 @@
 import time
 import threading
+import functools
 
 import sublime
 import sublime_plugin
@@ -46,15 +47,9 @@ class UpgradeAllPackagesThread(threading.Thread, PackageInstaller):
             # Pause so packages can be disabled
             time.sleep(0.7)
 
-            # We use a function to generate the on-complete lambda because if
-            # we don't, the lambda will bind to info at the current scope, and
-            # thus use the last value of info from the loop
-            def make_on_complete(name):
-                return lambda: self.reenable_package(name)
-
             for info in package_list:
                 if info[0] in disabled_packages:
-                    on_complete = make_on_complete(info[0])
+                    on_complete = functools.partial(self.reenable_package, info[0])
                 else:
                     on_complete = None
                 thread = PackageInstallerThread(self.manager, info[0],

--- a/package_control/commands/upgrade_all_packages_command.py
+++ b/package_control/commands/upgrade_all_packages_command.py
@@ -49,6 +49,8 @@ class UpgradeAllPackagesThread(threading.Thread, PackageInstaller):
 
             for info in package_list:
                 if info[0] in disabled_packages:
+                    # We use a functools.partial to generate the on-complete callback in
+                    # order to bind the current value of the parameters, unlike lambdas.
                     on_complete = functools.partial(self.reenable_package, info[0])
                 else:
                     on_complete = None

--- a/package_control/package_cleanup.py
+++ b/package_control/package_cleanup.py
@@ -163,6 +163,8 @@ class PackageCleanup(threading.Thread):
                     # to be done in the main Sublime Text thread.
                     package_filename = os.path.join(installed_path, file)
 
+                    # We use a functools.partial to generate the on-complete callback in
+                    # order to bind the current value of the parameters, unlike lambdas.
                     sublime.set_timeout(functools.partial(
                         self.remove_package_file, package_name, package_filename), 10)
 

--- a/package_control/package_cleanup.py
+++ b/package_control/package_cleanup.py
@@ -1,5 +1,6 @@
 import threading
 import os
+import functools
 
 import sublime
 
@@ -161,12 +162,9 @@ class PackageCleanup(threading.Thread):
                     # do a dance where we disable the package first, which has
                     # to be done in the main Sublime Text thread.
                     package_filename = os.path.join(installed_path, file)
-                    # Invoke a function to build the callback since we are in a loop
-                    # and the variable values will change by the time the callback is
-                    # actually called
-                    def build_lambda(name, filename):
-                        return lambda: self.remove_package_file(name, filename)
-                    sublime.set_timeout(build_lambda(package_name, package_filename), 10)
+
+                    sublime.set_timeout(functools.partial(
+                        self.remove_package_file, package_name, package_filename), 10)
 
                 else:
                     found_packages.append(package_name)

--- a/package_control/package_installer.py
+++ b/package_control/package_installer.py
@@ -211,5 +211,6 @@ class PackageInstallerThread(threading.Thread):
         try:
             self.result = self.manager.install_package(self.package)
         finally:
-            if self.on_complete:
+            # Do not reenable if deferred until next restart
+            if self.on_complete and self.result is not None:
                 sublime.set_timeout(self.on_complete, 700)

--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -1357,7 +1357,8 @@ class PackageManager():
         :param package_name:
             The package to delete
 
-        :return: bool if the package was successfully deleted
+        :return: bool if the package was successfully deleted or None
+                 if the package needs to be cleaned up on the next restart
         """
 
         exclude_dependencies = not is_dependency
@@ -1438,7 +1439,7 @@ class PackageManager():
             # Remove dependencies that are no longer needed
             self.cleanup_dependencies(package_name)
 
-        return True
+        return True if can_delete_dir else None
 
     def record_usage(self, params):
         """

--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -670,7 +670,9 @@ class PackageManager():
         :param is_dependency:
             If the package is a dependency
 
-        :return: bool if the package was successfully installed
+        :return: bool if the package was successfully deleted or None
+                 if the package needs to be cleaned up on the next restart
+                 and should not be reenabled
         """
 
         debug = self.settings.get('debug')
@@ -855,10 +857,18 @@ class PackageManager():
             if os.path.exists(unpacked_metadata_file) and not unpack:
                 self.backup_package_dir(package_name)
                 if not clear_directory(unpacked_package_dir):
-                    # If there is an error deleting now, we will mark it for
-                    # cleanup the next time Sublime Text starts
-                    open_compat(os.path.join(unpacked_package_dir,
-                        'package-control.cleanup'), 'w').close()
+                    # If deleting failed, queue the package to upgrade upon next start
+                    # where it will be disabled
+                    reinstall_file = os.path.join(unpacked_package_dir, 'package-control.reinstall')
+                    open_compat(reinstall_file, 'w').close()
+
+                    # Don't delete the metadata file, that way we have it
+                    # when the reinstall happens, and the appropriate
+                    # usage info can be sent back to the server
+                    clear_directory(unpacked_package_dir, [reinstall_file, unpacked_metadata_file])
+
+                    show_error(u'An error occurred while trying to upgrade %s. Please restart Sublime Text to finish the upgrade.' % package_name)
+                    return None
                 else:
                     os.rmdir(unpacked_package_dir)
 
@@ -965,7 +975,7 @@ class PackageManager():
                 clear_directory(package_dir, [reinstall_file, package_metadata_file])
 
                 show_error(u'An error occurred while trying to upgrade %s. Please restart Sublime Text to finish the upgrade.' % package_name)
-                return False
+                return None
 
             # Here we clean out any files that were not just overwritten. It is ok
             # if there is an error removing a file. The next time there is an
@@ -1359,6 +1369,7 @@ class PackageManager():
 
         :return: bool if the package was successfully deleted or None
                  if the package needs to be cleaned up on the next restart
+                 and should not be reenabled
         """
 
         exclude_dependencies = not is_dependency

--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -741,14 +741,14 @@ class PackageManager():
                     return False
                 return GitUpgrader(self.settings['git_binary'],
                     self.settings['git_update_command'], unpacked_package_dir,
-                    self.settings['cache_length'], self.settings['debug']).run()
+                    self.settings['cache_length'], debug).run()
             elif os.path.exists(os.path.join(unpacked_package_dir, '.hg')):
                 if self.settings.get('ignore_vcs_packages'):
                     show_error(u'Skipping hg package %s since the setting ignore_vcs_packages is set to true' % package_name)
                     return False
                 return HgUpgrader(self.settings['hg_binary'],
                     self.settings['hg_update_command'], unpacked_package_dir,
-                    self.settings['cache_length'], self.settings['debug']).run()
+                    self.settings['cache_length'], debug).run()
 
             old_version = self.get_metadata(package_name, is_dependency=is_dependency).get('version')
             is_upgrade = old_version != None

--- a/package_control/package_renamer.py
+++ b/package_control/package_renamer.py
@@ -82,6 +82,7 @@ class PackageRenamer(PackageDisabler):
 
             sublime.set_timeout(lambda: self.disable_packages(package_name, 'remove'), 10)
 
+            remove_result = True
             if not os.path.exists(new_package_path) or (case_insensitive_fs and changing_case):
                 sublime.set_timeout(lambda: self.disable_packages(new_package_name, 'install'), 10)
                 time.sleep(0.7)
@@ -103,12 +104,14 @@ class PackageRenamer(PackageDisabler):
 
             else:
                 time.sleep(0.7)
-                installer.manager.remove_package(package_name)
+                remove_result = installer.manager.remove_package(package_name)
                 message_string = u'Removed %s since package with new name (%s) already exists' % (
                     package_name, new_package_name)
                 console_write(message_string, True)
 
-            sublime.set_timeout(lambda: self.reenable_package(package_name, 'remove'), 700)
+            # Do not reenable if removal has been delayed until next restart
+            if remove_result is not None:
+                sublime.set_timeout(lambda: self.reenable_package(package_name, 'remove'), 700)
 
             try:
                 installed_packages.remove(package_name)


### PR DESCRIPTION
This includes when packages are removed, when a package is renamed and when an updated package used to containe `.no-sublime-package` but does not anymore and removing the files failed.

Actually fixes #835.

(I also couldn't resist using `functools.partial`. You may choose to not include that commit of course.)