### PR TITLE
Fix prerelease and metadata info not in update msg

### DIFF
--- a/package_control/automatic_upgrader.py
+++ b/package_control/automatic_upgrader.py
@@ -252,10 +252,13 @@ class AutomaticUpgrader(threading.Thread):
 
                 self.installer.manager.install_package(info[0])
 
-                version = re.sub('^.*?(v[\d\.]+).*?$', '\\1', info[2])
-                if version == info[2] and version.find('pull with') != -1:
-                    vcs = re.sub('^pull with (\w+).*?$', '\\1', version)
+                version = re.search(r'v[^;\s]+', info[2])
+                if version:
+                    version = version.group()
+                elif 'pull with' in info[2].find():
+                    vcs = re.search(r'^pull with (\w+)', info[2]).group(1)
                     version = 'latest %s commit' % vcs
+
                 message_string = u'Upgraded %s to %s' % (info[0], version)
                 console_write(message_string, True)
                 if on_complete:

--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -667,7 +667,7 @@ class PackageManager():
         :param is_dependency:
             If the package is a dependency
 
-        :return: bool if the package was successfully deleted or None
+        :return: bool if the package was successfully installed or None
                  if the package needs to be cleaned up on the next restart
                  and should not be reenabled
         """


### PR DESCRIPTION
Today I restarted ST and found out that "PC 3.0.2" was installed, which was kind if surprising to me since the beta is rather recent. After some investigation If found out that 3.0.2 wasn't actually the version, it was 3.0.2-beta.

So I fixed it.

Imo doing this string parsing is incredibly inconvenient and I feel like either `make_package_list` or the upgrading function need some adjustments, but this was not in my scope.

I also noticed that the new version is not displayed when the update is triggered manually (e.g. though UpgradePackageCommand or UpgradeAllPackagesCommand) and also not when installation was successful in the AdvancedInstallPackageCommand. Separate issue?