### PR TITLE
Keep quick panels open if possible (st>=3070)

### DIFF
--- a/package_control/commands/disable_package_command.py
+++ b/package_control/commands/disable_package_command.py
@@ -2,6 +2,7 @@ import sublime
 import sublime_plugin
 
 from ..show_error import show_error
+from ..show_quick_panel import show_quick_panel
 from ..package_manager import PackageManager
 from ..settings import preferences_filename
 from ..package_disabler import PackageDisabler
@@ -25,7 +26,7 @@ class DisablePackageCommand(sublime_plugin.WindowCommand, PackageDisabler):
         if not self.package_list:
             show_error('There are no enabled packages to disable.')
             return
-        self.window.show_quick_panel(self.package_list, self.on_done)
+        show_quick_panel(self.window, self.package_list, self.on_done)
 
     def on_done(self, picked):
         """

--- a/package_control/commands/enable_package_command.py
+++ b/package_control/commands/enable_package_command.py
@@ -2,6 +2,7 @@ import sublime
 import sublime_plugin
 
 from ..show_error import show_error
+from ..show_quick_panel import show_quick_panel
 from ..settings import preferences_filename
 from ..package_disabler import PackageDisabler
 
@@ -19,7 +20,7 @@ class EnablePackageCommand(sublime_plugin.WindowCommand, PackageDisabler):
         if not self.disabled_packages:
             show_error('There are no disabled packages to enable.')
             return
-        self.window.show_quick_panel(self.disabled_packages, self.on_done)
+        show_quick_panel(self.window, self.disabled_packages, self.on_done)
 
     def on_done(self, picked):
         """

--- a/package_control/commands/install_package_command.py
+++ b/package_control/commands/install_package_command.py
@@ -44,9 +44,10 @@ class InstallPackageThread(threading.Thread, PackageInstaller):
         self.package_list = self.make_package_list(['upgrade', 'downgrade',
             'reinstall', 'pull', 'none'])
 
-        def show_quick_panel():
+        def show_panel():
             if not self.package_list:
                 show_error('There are no packages available for installation')
                 return
             self.window.show_quick_panel(self.package_list, self.on_done)
-        sublime.set_timeout(show_quick_panel, 10)
+
+        sublime.set_timeout(show_panel, 10)

--- a/package_control/commands/install_package_command.py
+++ b/package_control/commands/install_package_command.py
@@ -4,6 +4,7 @@ import sublime
 import sublime_plugin
 
 from ..show_error import show_error
+from ..show_quick_panel import show_quick_panel
 from ..package_installer import PackageInstaller
 from ..thread_progress import ThreadProgress
 
@@ -48,6 +49,6 @@ class InstallPackageThread(threading.Thread, PackageInstaller):
             if not self.package_list:
                 show_error('There are no packages available for installation')
                 return
-            self.window.show_quick_panel(self.package_list, self.on_done)
+            show_quick_panel(self.window, self.package_list, self.on_done)
 
         sublime.set_timeout(show_panel, 10)

--- a/package_control/commands/list_packages_command.py
+++ b/package_control/commands/list_packages_command.py
@@ -5,6 +5,7 @@ import sublime
 import sublime_plugin
 
 from ..show_error import show_error
+from ..show_quick_panel import show_quick_panel
 from ..package_manager import PackageManager
 from .existing_packages_command import ExistingPackagesCommand
 
@@ -56,7 +57,7 @@ class ListPackagesThread(threading.Thread, ExistingPackagesCommand):
             if not self.package_list:
                 show_error('There are no packages to list')
                 return
-            self.window.show_quick_panel(self.package_list, self.on_done)
+            show_quick_panel(self.window, self.package_list, self.on_done)
         sublime.set_timeout(show_panel, 10)
 
     def on_done(self, picked):

--- a/package_control/commands/list_packages_command.py
+++ b/package_control/commands/list_packages_command.py
@@ -52,12 +52,12 @@ class ListPackagesThread(threading.Thread, ExistingPackagesCommand):
         if self.filter_function:
             self.package_list = list(filter(self.filter_function, self.package_list))
 
-        def show_quick_panel():
+        def show_panel():
             if not self.package_list:
                 show_error('There are no packages to list')
                 return
             self.window.show_quick_panel(self.package_list, self.on_done)
-        sublime.set_timeout(show_quick_panel, 10)
+        sublime.set_timeout(show_panel, 10)
 
     def on_done(self, picked):
         """

--- a/package_control/commands/remove_channel_command.py
+++ b/package_control/commands/remove_channel_command.py
@@ -2,6 +2,7 @@ import sublime
 import sublime_plugin
 
 from ..show_error import show_error
+from ..show_quick_panel import show_quick_panel
 from ..settings import pc_settings_filename
 
 
@@ -29,7 +30,7 @@ class RemoveChannelCommand(sublime_plugin.WindowCommand):
             run = True
 
         if run:
-            self.window.show_quick_panel(self.channels, self.on_done)
+            show_quick_panel(self.window, self.channels, self.on_done)
 
     def on_done(self, index):
         """

--- a/package_control/commands/remove_package_command.py
+++ b/package_control/commands/remove_package_command.py
@@ -5,6 +5,7 @@ import sublime
 import sublime_plugin
 
 from ..show_error import show_error
+from ..show_quick_panel import show_quick_panel
 from .existing_packages_command import ExistingPackagesCommand
 from ..thread_progress import ThreadProgress
 from ..package_disabler import PackageDisabler
@@ -34,7 +35,7 @@ class RemovePackageCommand(sublime_plugin.WindowCommand,
         if not self.package_list:
             show_error('There are no packages that can be removed.')
             return
-        self.window.show_quick_panel(self.package_list, self.on_done)
+        show_quick_panel(self.window, self.package_list, self.on_done)
 
     def on_done(self, picked):
         """

--- a/package_control/commands/remove_repository_command.py
+++ b/package_control/commands/remove_repository_command.py
@@ -2,6 +2,7 @@ import sublime
 import sublime_plugin
 
 from ..show_error import show_error
+from ..show_quick_panel import show_quick_panel
 from ..settings import pc_settings_filename
 
 
@@ -18,7 +19,7 @@ class RemoveRepositoryCommand(sublime_plugin.WindowCommand):
             show_error(u'There are no repositories to remove.')
             return
 
-        self.window.show_quick_panel(self.repositories, self.on_done)
+        show_quick_panel(self.window, self.repositories, self.on_done)
 
     def on_done(self, index):
         """

--- a/package_control/commands/upgrade_package_command.py
+++ b/package_control/commands/upgrade_package_command.py
@@ -51,12 +51,12 @@ class UpgradePackageThread(threading.Thread, PackageInstaller):
         self.package_list = self.make_package_list(['install', 'reinstall',
             'none'])
 
-        def show_quick_panel():
+        def show_panel():
             if not self.package_list:
                 show_error('There are no packages ready for upgrade')
                 return
             self.window.show_quick_panel(self.package_list, self.on_done)
-        sublime.set_timeout(show_quick_panel, 10)
+        sublime.set_timeout(show_panel, 10)
 
     def on_done(self, picked):
         """

--- a/package_control/commands/upgrade_package_command.py
+++ b/package_control/commands/upgrade_package_command.py
@@ -4,6 +4,7 @@ import sublime
 import sublime_plugin
 
 from ..show_error import show_error
+from ..show_quick_panel import show_quick_panel
 from ..thread_progress import ThreadProgress
 from ..package_installer import PackageInstaller, PackageInstallerThread
 from ..package_renamer import PackageRenamer
@@ -55,7 +56,7 @@ class UpgradePackageThread(threading.Thread, PackageInstaller):
             if not self.package_list:
                 show_error('There are no packages ready for upgrade')
                 return
-            self.window.show_quick_panel(self.package_list, self.on_done)
+            show_quick_panel(self.window, self.package_list, self.on_done)
         sublime.set_timeout(show_panel, 10)
 
     def on_done(self, picked):

--- a/package_control/package_creator.py
+++ b/package_control/package_creator.py
@@ -3,6 +3,7 @@ import os
 import sublime
 
 from .show_error import show_error
+from .show_quick_panel import show_quick_panel
 from .package_manager import PackageManager
 
 
@@ -22,7 +23,7 @@ class PackageCreator():
         if not self.packages:
             show_error('There are no packages available to be packaged')
             return
-        self.window.show_quick_panel(self.packages, self.on_done)
+        show_quick_panel(self.window, self.packages, self.on_done)
 
     def on_done(self, picked):
         """
@@ -51,7 +52,7 @@ class PackageCreator():
             self.profiles.append(key)
 
         def show_panel():
-            self.window.show_quick_panel(self.profiles, self.on_done_profile)
+            show_quick_panel(self.window, self.profiles, self.on_done_profile)
         sublime.set_timeout(show_panel, 50)
 
     def on_done_profile(self, picked):

--- a/package_control/show_quick_panel.py
+++ b/package_control/show_quick_panel.py
@@ -8,7 +8,7 @@ def show_quick_panel(window, *args, **kwargs):
     Accepts same parameters as window.show_quick_panel, plus:
 
     :param window:
-        Same as for window.show_quick_panel
+        sublime.Window instance where the panel should be shown.
     """
     if int(sublime.version()) >= 3070:
         # Override the flags parameter to include the KEEP_OPEN_ON_FOCUS_LOST

--- a/package_control/show_quick_panel.py
+++ b/package_control/show_quick_panel.py
@@ -1,0 +1,23 @@
+import sublime
+
+
+def show_quick_panel(window, *args, **kwargs):
+    """
+    Wrapper for the window.show_quick_panel API that keeps it open.
+
+    Accepts same parameters as window.show_quick_panel, plus:
+
+    :param window:
+        Same as for window.show_quick_panel
+    """
+    if int(sublime.version()) >= 3070:
+        # Override the flags parameter to include the KEEP_OPEN_ON_FOCUS_LOST
+        # flag
+        import inspect
+        sig = inspect.signature(window.show_quick_panel)
+        ba = sig.bind(*args, **kwargs)
+        ba.arguments['flags'] = (ba.arguments.get('flags', 0)
+                                 | sublime.KEEP_OPEN_ON_FOCUS_LOST)
+        args, kwargs = ba.args, ba.kwargs
+
+    return window.show_quick_panel(*args, **kwargs)


### PR DESCRIPTION
Introduced a new wrapper function and used it everywhere since I didn't see a reason why one of these panels should not remain open.

In case this might change in the future, a new keyword parameter could be added to the wrapper function that will make it not add the flag, or just use the API directly.

Closes #895.