### PR TITLE
Rename in other dir when changing case on Windows

### DIFF
--- a/package_control/package_renamer.py
+++ b/package_control/package_renamer.py
@@ -92,8 +92,9 @@ class PackageRenamer(PackageDisabler):
                 # a different case, so we work around that with a temporary name
                 if os.name == 'nt' and changing_case:
                     temp_package_name = '__' + new_package_name
-                    temp_package_path = os.path.join(sublime.packages_path(),
-                        temp_package_name)
+                    temp_package_path = os.path.join(
+                        os.path.dirname(sublime.packages_path()), temp_package_name
+                    )
                     os.rename(package_path, temp_package_path)
                     package_path = temp_package_path
 


### PR DESCRIPTION
Probably not going to be much of an issue, but previously this *could*
lead to ST loading the "new" package from the temp path, albeit it would
likely be too slow. With this change this can't happen.