### PR TITLE
Don't report the User package as default on ST2

### DIFF
--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -520,8 +520,10 @@ class PackageManager():
         else:
             files = os.listdir(os.path.join(os.path.dirname(
                 sublime.packages_path()), 'Pristine Packages'))
-            files = list(set(files) - set(os.listdir(
-                sublime.installed_packages_path())))
+            files = list(set(files)
+                         - set(os.listdir(sublime.installed_packages_path())))
+            if "User.sublime-package" in files:  # Don't ask why
+                files.remove("User.sublime-package")
         packages = [file.replace('.sublime-package', '') for file in files]
         packages = sorted(packages, key=lambda s: s.lower())
         return packages


### PR DESCRIPTION
Apparently, ST2 includes a few default files in a Pristine Package named User. Since we know that the User package is not a default package, we exlude it manually.