### PR TITLE
Fix usage of console_write

### DIFF
--- a/package_control/automatic_upgrader.py
+++ b/package_control/automatic_upgrader.py
@@ -143,7 +143,7 @@ class AutomaticUpgrader(threading.Thread):
 
             for dependency in self.missing_dependencies:
                 if self.installer.manager.install_package(dependency, is_dependency=True):
-                    console_write(u'Installed missing dependency %s' % dependency, True)
+                    console_write(u'Installed missing dependency %s, dependency)
                     dependencies_installed += 1
 
             if dependencies_installed:


### PR DESCRIPTION
```
Exception in thread Thread-8:
Traceback (most recent call last):
  File "./threading.py", line 901, in _bootstrap_inner
  File "package_control.automatic_upgrader in C:\Users\Fichte\AppData\Roaming\Sublime Text 3\Installed Packages\Package Control.sublime-package", line 113, in run
  File "package_control.automatic_upgrader in C:\Users\Fichte\AppData\Roaming\Sublime Text 3\Installed Packages\Package Control.sublime-package", line 146, in install_missing
  File "package_control.console_write in C:\Users\Fichte\AppData\Roaming\Sublime Text 3\Installed Packages\Package Control.sublime-package", line 34, in console_write
  File "package_control.text in C:\Users\Fichte\AppData\Roaming\Sublime Text 3\Installed Packages\Package Control.sublime-package", line 57, in format
TypeError: not all arguments converted during string formatting
```

Seemingly forgotten in b03bd6df703124641830cb5c0b9e961fc20d4cda.