### PR TITLE
Fix removing dependencies

### DIFF
--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -550,7 +550,8 @@ class PackageManager():
             packages |= self._list_sublime_package_files(sublime.installed_packages_path())
 
         packages -= set(self.list_default_packages())
-        packages -= set(self.list_dependencies())
+        if exclude_dependencies:
+            packages -= set(self.list_dependencies())
         packages -= set(['User', 'Default'])
         return sorted(packages, key=lambda s: s.lower())
 


### PR DESCRIPTION
Since dependencies were always removed from the packages list,
PC would always complain about the dependency not being installed.
Dependencies were essentially unremovable.

Regression from b818f7b7efdfedaa0974b5ad92d0ffb1081b9846.