### PR TITLE
Refactor package listing

### DIFF
--- a/package_control/automatic_upgrader.py
+++ b/package_control/automatic_upgrader.py
@@ -48,10 +48,8 @@ class AutomaticUpgrader(threading.Thread):
         self.determine_next_run()
 
         # Detect if a package is missing that should be installed
-        self.missing_packages = list(set(self.installed_packages) -
-            set(found_packages))
-        self.missing_dependencies = list(set(self.manager.find_required_dependencies()) -
-            set(found_dependencies))
+        self.missing_packages = set(self.installed_packages) - found_packages
+        self.missing_dependencies = self.manager.find_required_dependencies() - found_dependencies
 
         if self.auto_upgrade and self.next_run <= time.time():
             self.save_last_run(time.time())

--- a/package_control/commands/disable_package_command.py
+++ b/package_control/commands/disable_package_command.py
@@ -16,13 +16,12 @@ class DisablePackageCommand(sublime_plugin.WindowCommand, PackageDisabler):
 
     def run(self):
         manager = PackageManager()
-        packages = manager.list_all_packages()
+        packages = manager.list_packages(exclude=['dependencies'])
         self.settings = sublime.load_settings(preferences_filename())
         ignored = self.settings.get('ignored_packages')
         if not ignored:
             ignored = []
-        self.package_list = list(set(packages) - set(ignored))
-        self.package_list = sorted(self.package_list, key=lambda s: s.lower())
+        self.package_list = sorted(packages - set(ignored), key=lambda s: s.lower())
         if not self.package_list:
             sublime.message_dialog(text.format(
                 u'''

--- a/package_control/package_cleanup.py
+++ b/package_control/package_cleanup.py
@@ -39,7 +39,7 @@ class PackageCleanup(threading.Thread):
 
         found_dependencies = []
         installed_dependencies = self.manager.list_dependencies()
-        extra_dependencies = list(set(installed_dependencies) - set(self.manager.find_required_dependencies()))
+        extra_dependencies = list(installed_dependencies - set(self.manager.find_required_dependencies()))
 
         # Clean up unneeded dependencies so that found_dependencies will only
         # end up having required dependencies added to it

--- a/package_control/package_creator.py
+++ b/package_control/package_creator.py
@@ -20,6 +20,7 @@ class PackageCreator():
 
         self.manager = PackageManager()
         self.packages = self.manager.list_packages(unpacked_only=True)
+        self.packages = sorted(self.packages, key=lambda s: s.lower())
         if not self.packages:
             show_error(
                 u'''


### PR DESCRIPTION
This also includes #941 because it would be a merge conflict otherwise.

Basically, I saw this again as I was fixing the bug in #941 and felt the urge to improve things a bit. There was lots of duplicated code and duplicated operations on the file
system which a) slowed down the code (even though not a lot) and b) was
just somewhat ugly.
Since I made the new method return a set, I also used this oppertunity to establish usage of sets in more places since lists (or rather order) was only required in three places iirc, when prompting the user to select a package.

This pull requests speeds up all previously used method variants compared to their new equivalents by a total of ~27%.

Code is verified to produce the same results as previously, except for `list_packages(unpacked_only=True)`, which now does not contain override packages anymore. (Override packages are unpacked packages that override contents of a `.sublime-package` file somewhere else and thus don't make sense to be packed. The CreatePackage command was the only one using this.)

The code I used for testing, which includes the updated `list_packages` command, requires 09b2a3a (#941, since otherwise the original results are wrong) and ST3:

``` py
import sys
import timeit
import unittest

import sublime
from package_control.package_manager import PackageManager

str_cls = str


class MyPackageManager(PackageManager):

    class LazyPackages(object):
        """A lazy but caching mapping which calculates attribute values only
        when needed.
        """

        def __getattr__(self, name):
            val = getattr(self, "_" + name)()
            setattr(self, name, val)
            return val

        def __init__(self, manager):
            self.manager = manager

        def _default(self):
            return self.manager._list_default_packages()
            # return set(self.manager.list_default_packages())

        def _installed(self):
            return self.manager._list_sublime_package_files(sublime.installed_packages_path())

        def _unpacked(self):
            return self.manager._list_visible_dirs(sublime.packages_path())

        def _dependencies(self):
            dependencies = set(name for name in self.unpacked if self.manager._is_dependency(name))
            if sys.version_info >= (3,):
                dependencies.add('0_package_control_loader')  # .sublime-package with ST3
            return dependencies

    def list_packages(self, include=['normal'], exclude=[], unpacked_only=False):
        """List all packages on the machine and filter them.

        :param include:
            A list of package type strings that should be included in the result,
            or the string `"*"` which translates to all packages.

            Allowed are:
            - dependencies - All dependencies
            - default - The default packages (minus Default)
            - normal - All packages that are not in any of the other categories
              (minus Default and User)

        :param exclude:
            Similar to above, but a list of package types that will be excluded
            from the result.
            This implicitly sets `include = "*"`.

        :param unpacked_only:
            If only unpacked packages should be considered.
            This implicitly sets `include = ['normal']` amd `exclude = []`.

        :return:
            A set of all packages as specified.
        """
        # Note: installed_packages, dependencies and default_packages are
        # subtracted for unpacked_only, because an unpacked package with the same
        # name would be incomplete since it overrides and dependencies are not
        # actual packages.
        if unpacked_only:
            include = ['normal']
        if exclude or include == '*':
            include = ['default', 'normal', 'dependencies']
            include = list(set(include) - set(exclude))
        if not include:
            return set()

        # We use a few shortcuts that don't require calculation of all
        # packages sets (which needs disk access).
        # A lazy and caching mapping is used to reduce duplicated code.
        packages = self.LazyPackages(self)

        if include == ['default']:
            # Speedup: Don't need installed, unpacked packages or dependencies
            return packages.default
        elif include == ['dependencies']:
            # Speedup: Don't need installed or default packages
            return packages.dependencies
        elif len(include) == 3:
            # Speedup: Don't need dependencies
            return (packages.unpacked | packages.installed | packages.default) - set(['User', 'Default'])

        # Subtraction is important. For example, normal packages that have the
        # same name as a default package are override packages and to be excluded
        # if the default packages are not requested.
        result = set()
        if 'normal' in include:
            result |= packages.unpacked

        if not unpacked_only:
            result |= packages.installed
        else:
            result -= packages.installed

        if 'dependencies' in include:
            result |= packages.dependencies
        else:
            result -= packages.dependencies

        if 'default' in include:
            result |= packages.default
        else:
            result -= packages.default

        result -= set(['User', 'Default'])
        return result


class MyPackageManagerTests(unittest.TestCase):
    pm_time = 0
    mpm_time = 0

    def assert_and_timeit(self, a, b, func):
        # actually do tests
        pm = PackageManager()
        mpm = MyPackageManager()
        a_res = eval(a, None, locals())
        b_res = eval(b, None, locals())
        func(a_res, sorted(b_res, key=str.lower))

        # time it
        t_a = timeit.timeit(a, setup="from package_control.package_manager import PackageManager;pm = PackageManager()", number=100)
        t_b = timeit.timeit(b, setup="from User.pc_list_packages_test import MyPackageManager; mpm = MyPackageManager()", number=100)
        print("time for %s: %f" % (a, t_a))
        print("time for %s: %f" % (b, t_b))
        self.pm_time += t_a
        self.mpm_time += t_b

    def customAssertEquals(self, a, b):
        self.assert_and_timeit(a, b, self.assertEquals)

    def customAssertNotEquals(self, a, b):
        self.assert_and_timeit(a, b, self.assertNotEquals)

    def test_list_packages_equivalence(self):
        self.customAssertEquals(
            "pm.list_all_packages()",
            "mpm.list_packages(exclude=['dependencies'])"
        )
        self.customAssertEquals(
            "pm.list_all_packages(exclude_dependencies=False)",
            "mpm.list_packages('*')"
        )
        self.customAssertEquals(
            "pm.list_default_packages()",
            "mpm.list_packages(['default'])"
        )
        self.customAssertEquals(
            "pm.list_dependencies()",
            "mpm.list_packages(['dependencies'])"
        )
        self.customAssertEquals(
            "pm.list_packages()",
            "mpm.list_packages()"
        )
        # Expected to fail because override packages are now excluded
        self.customAssertNotEquals(
            "pm.list_packages(unpacked_only=True)",
            "mpm.list_packages(unpacked_only=True)"
        )

        print("Total runtimes --- pm: %f, mpm: %f" % (self.pm_time, self.mpm_time))
        print("Change: %.02f%%" % (self.mpm_time / self.pm_time * 100))

    def test_list_packages(self):
        mpm = MyPackageManager()
        self.assertEquals(
            mpm.list_packages(exclude=['dependencies']),
            mpm.list_packages(['default', 'normal'])
        )

        self.assertNotIn("Default", mpm.list_packages(['default', 'normal']))
        self.assertNotIn("Default", mpm.list_packages('*'))
        self.assertNotIn("User", mpm.list_packages(['default', 'normal']))


def plugin_loaded():
    MyPackageManager().list_packages('*')
    suite = unittest.TestLoader().loadTestsFromTestCase(MyPackageManagerTests)
    unittest.TextTestRunner(stream=sys.stdout).run(suite)
```

Selected results (representative for current code state):

``` py
# WITHOUT ALL PACKAGES SPEEDUP
# reloading plugin User.pc_list_packages_test
# .time for pm.list_all_packages(): 0.905260
# time for mpm.list_packages(exclude=['dependencies']): 0.577788
# time for pm.list_all_packages(exclude_dependencies=False): 0.367331
# time for mpm.list_packages('*'): 0.575678
# time for pm.list_default_packages(): 0.021200
# time for mpm.list_packages(['default']): 0.021253
# time for pm.list_dependencies(): 0.511155
# time for mpm.list_packages(['dependencies']): 0.534655
# time for pm.list_packages(): 0.861787
# time for mpm.list_packages(): 0.554115
# time for pm.list_packages(unpacked_only=True): 0.844691
# time for mpm.list_packages(unpacked_only=True): 0.573436
# Total runtimes --- pm: 3.511424, mpm: 2.836925
# Change: 80.79%
# .
# ----------------------------------------------------------------------
# Ran 2 tests in 6.450s
#
# WITH ALL PACKAGES SPEEDUP
# reloading plugin User.pc_list_packages_test
# .time for pm.list_all_packages(): 0.891038
# time for mpm.list_packages(exclude=['dependencies']): 0.558296
# time for pm.list_all_packages(exclude_dependencies=False): 0.372157
# time for mpm.list_packages('*'): 0.339623
# time for pm.list_default_packages(): 0.021686
# time for mpm.list_packages(['default']): 0.021691
# time for pm.list_dependencies(): 0.508321
# time for mpm.list_packages(['dependencies']): 0.532805
# time for pm.list_packages(): 0.852161
# time for mpm.list_packages(): 0.564845
# time for pm.list_packages(unpacked_only=True): 0.826859
# time for mpm.list_packages(unpacked_only=True): 0.558073
# Total runtimes --- pm: 3.472223, mpm: 2.575333
# Change: 74.17%
# .
# ----------------------------------------------------------------------
# Ran 2 tests in 6.145s
#
# WITH LAZY PACKAGES
# reloading plugin User.pc_list_packages_test
# .time for pm.list_all_packages(): 0.902987
# time for mpm.list_packages(exclude=['dependencies']): 0.570071
# time for pm.list_all_packages(exclude_dependencies=False): 0.374518
# time for mpm.list_packages('*'): 0.342308
# time for pm.list_default_packages(): 0.022072
# time for mpm.list_packages(['default']): 0.022726
# time for pm.list_dependencies(): 0.515908
# time for mpm.list_packages(['dependencies']): 0.513074
# time for pm.list_packages(): 0.864027
# time for mpm.list_packages(): 0.583057
# time for pm.list_packages(unpacked_only=True): 0.856370
# time for mpm.list_packages(unpacked_only=True): 0.574159
# Total runtimes --- pm: 3.535882, mpm: 2.605394
# Change: 73.68%
# .
# ----------------------------------------------------------------------
# Ran 2 tests in 6.270s
```
