### PR TITLE
Wrong number of parameters for self.show_error

### DIFF
--- a/package_control/commands/satisfy_dependencies_command.py
+++ b/package_control/commands/satisfy_dependencies_command.py
@@ -35,6 +35,7 @@ class SatisfyDependenciesThread(threading.Thread):
         self.manager = manager
         threading.Thread.__init__(self)
 
+    @staticmethod
     def show_error(msg):
         sublime.set_timeout(functools.partial(show_error, msg), 10)
 


### PR DESCRIPTION
I had a traceback once, but I closed the view I kept it in.

Basically, wrong number of arguments for the threaded `show_error` method lead to messages not being shown by the satisfy command. I used a staticmethod since it doesn't depend on self or cls.