### PR TITLE
Correct removal of list item from list.

### DIFF
--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -813,7 +813,8 @@ class PackageManager():
         trailing_package_dir = package_dir + slash if package_dir[-1] != slash else package_dir
         package_dir_regex = re.compile('^' + re.escape(trailing_package_dir))
         for root, dirs, files in os.walk(package_dir):
-            [dirs.remove(dir_) for dir_ in dirs if dir_ in dirs_to_ignore]
+            # add "dir" to "paths" list if "dir" is not in "dirs_to_ignore"
+            dirs[:] = [x for x in dirs if x not in dirs_to_ignore]
             paths = dirs
             paths.extend(files)
             for path in paths:


### PR DESCRIPTION
When modifying a list that you're iterating through, python does not keep track of what the current index should be in the loop.

In the case of the old code, 

      [dirs.remove(dir_) for dir_ in dirs if dir_ in dirs_to_ignore]

while iterating through dirs, python will store an index of its current location in the list. This results in the code skipping elements in the iteration of the list because the code above modifies the list it is iterating on. 

Imagine the lists:

     dirs = ['a', 'b', 'c', 'd', 'e']
     dirs_to_ignore = ['a', 'c']

If the current index is ```dirs[2]``` ( ```'c'``` ), and ```dirs[2]``` is in ```dirs_to_ignore``` (which it is), then ```dirs.remove(dir_)``` is called. That successfully removes ```'c'``` from the ```dirs``` list, but python then bumps the current list index iterator to 3, which in our new list ( ```['a', 'b', 'd', 'e']``` ) is ```'e'```, meaning we've just skipped an element ( ```'d'``` ) of the ```dirs``` list to check.

This pull request fixes that issue. 


    >>> dirs = ['a', 'b', 'c', 'd', 'e']
    >>> dirs_to_ignore = ['a', 'c']
    >>> paths = [x for x in dirs if x not in dirs_to_ignore]
    >>> paths
    ['b', 'd', 'e']

