### PR TITLE
Mark the packages_cache as required.

### DIFF
--- a/example-channel.json
+++ b/example-channel.json
@@ -12,7 +12,7 @@
 		"https://github.com/SublimeText"
 	],
 
-	// The "packages_cache" is completely optional, but allows the
+	// The "packages_cache" is required and allows the
 	// channel to cache and deliver package data from multiple
 	// repositories in a single HTTP request, allowing for significantly
 	// improved performance.


### PR DESCRIPTION
Currently, without the packages_cache in the channel json, no packages can be discovered.  This has something to do with the way the PackageManager builds its list of repositories.  In the [list_repositories method](https://github.com/wbond/package_control/blob/818b598a0e0259b791cbee638de2575ef2653195/package_control/package_manager.py#L383) it checks in the package_cache for info about the "releases" for a repository and if they are not found then the package goes into the unavailable packages list and doesn't become available to install. 

I verified this claim by forking channel_v3.json in gist and removing the package_cache and replacing my main feed with that one and it failed to discover any repositories to install.  [forked channel here](https://gist.githubusercontent.com/anonymous/2a60a2c19742d2157cfb/raw/979cd64b3e47a4ba78f5cebafbb96b9cfc8d5416/channel_v3.json).

I think either this change should be made to the channel documentation or a fix to the PackageManager, but this change is it only one I have time for now so proposing this.  If you think the PackageManager should be fixed instead (or if I misunderstood something) then please reject this request.