### PR TITLE
Update log messages for dependency installations

### DIFF
--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -889,7 +889,7 @@ class PackageManager():
             return False
 
         if not is_available:
-            message = u'The %s specified, %s, is not available'
+            message = u"The %s '%s' is not available"
             params = (package_type, package_name)
             if is_dependency:
                 console_write(message, params)
@@ -1420,7 +1420,7 @@ class PackageManager():
             available_version = version_comparable(available_version) if available_version else None
 
             def dependency_write(msg):
-                msg = u"The dependency {dependency} " + msg
+                msg = u"The dependency '{dependency}' " + msg
                 msg = msg.format(
                     dependency=dependency,
                     installed_version=installed_version,

--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -1462,8 +1462,8 @@ class PackageManager():
                     if fail_early:
                         return False
                     error = True
-
-                dependency_write(u'has successfully been installed or updated')
+                else:
+                    dependency_write(u'has successfully been installed or updated')
 
         return not error
 

--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -1435,7 +1435,7 @@ class PackageManager():
             install_dependency = False
             if not os.path.exists(dependency_dir):
                 install_dependency = True
-                dependency_write(u'is not currently installed; installing')
+                dependency_write(u'is not currently installed; installing...')
             elif os.path.exists(dependency_git_dir):
                 dependency_write_debug(u'is installed via git; leaving alone')
             elif os.path.exists(dependency_hg_dir):
@@ -1448,10 +1448,10 @@ class PackageManager():
                 dependency_write(u'is installed, but the latest available release could not be determined; leaving alone')
             elif not installed_version:
                 install_dependency = True
-                dependency_write(u'is installed, but its version is not known; upgrading to latest release {available_version}')
+                dependency_write(u'is installed, but its version is not known; upgrading to latest release {available_version}...')
             elif installed_version < available_version:
                 install_dependency = True
-                dependency_write(u'is installed, but out of date; upgrading to latest release {available_version} from {installed_version}')
+                dependency_write(u'is installed, but out of date; upgrading to latest release {available_version} from {installed_version}...')
             else:
                 dependency_write_debug(u'is installed and up to date ({installed_version}); leaving alone')
 


### PR DESCRIPTION
Thanks to https://github.com/LaTeXing/LaTeXing/issues/198#issuecomment-168591507 I noticed the bug where a dependency would be reported as both successfully and unsuccesfully installed.

While working on it, I improved some other relevant sections as well.

Before:
```
Package Control: The dependency requests is not currently installed; installing
Package Control: The dependency specified, requests, is not available
Package Control: The dependency requests could not be installed or updated
Package Control: The dependency requests has successfully been installed or updated
```

After (includes all changes in this PR):
```
Package Control: The dependency 'requests' is not currently installed; installing...
Package Control: The dependency 'requests' is not available
Package Control: The dependency 'requests' could not be installed or updated
```