### PR TITLE
Workaround to prevent issue 1002

### DIFF
--- a/package_control/ca_certs.py
+++ b/package_control/ca_certs.py
@@ -352,7 +352,9 @@ def _osx_get_distrusted_certs(settings):
     """
 
     args = ['/usr/bin/security', 'dump-trust-settings', '-d']
-    result = Cli(None, settings.get('debug')).execute(args, '/usr/bin', ignore_errors='No Trust Settings were found')
+    result = Cli(None, settings.get('debug')).execute(args, '/usr/bin',
+        ignore_errors='No Trust Settings were found|SecTrustSettingsCopyTrustSettings: The specified item '
+                      'could not be found in the keychain.')
 
     if not result:
         return []


### PR DESCRIPTION
Workaround to prevent issue 1002 while waiting for @wbond to push new trust_list code.

Ignore 'The specified item could not be found in the keychain' error reported by OS X command '/usr/bin/security dump-trust-settings -d'