### PR TITLE
correctly highlight sublime-package file when opening dir

### DIFF
--- a/package_control/commands/list_packages_command.py
+++ b/package_control/commands/list_packages_command.py
@@ -82,7 +82,16 @@ class ListPackagesThread(threading.Thread, ExistingPackagesCommand):
 
         def open_dir():
             package_dir = self.manager.get_package_dir(package_name)
+            package_file = None
             if not os.path.exists(package_dir):
                 package_dir = self.manager.settings['installed_packages_path']
-            self.window.run_command('open_dir', {"dir": package_dir})
+                package_file = package_name + '.sublime-package'
+                if not os.path.exists(os.path.join(package_dir, package_file)):
+                    package_file = None
+
+            open_dir_file = { 'dir': package_dir }
+            if package_file is not None:
+                open_dir_file['file'] = package_file
+
+            self.window.run_command('open_dir', open_dir_file)
         sublime.set_timeout(open_dir, 10)


### PR DESCRIPTION
correctly highlight sublime-package file when opening dir from the List [Installed] Packages command. 

Previously, it would just open the Installed Packages folder with no selection, and it would be up to the user to locate the `.sublime-package` file manually.