### PR TITLE
Added the setting detection for config.sublime-package-override

### DIFF
--- a/package_control/package_cleanup.py
+++ b/package_control/package_cleanup.py
@@ -153,7 +153,8 @@ class PackageCleanup(threading.Thread):
             clean_old_files(package_dir)
 
             if int(sublime.version()) > 3000 and os.path.exists(package_dir + '/.sublime-package-override'):
-                found = False
+                if not os.path.exists(package_dir + '/.no-sublime-package'):
+                    found = False
 
             # Cleanup packages/dependencies that could not be removed due to in-use files
             cleanup_file = os.path.join(package_dir, 'package-control.cleanup')

--- a/package_control/package_cleanup.py
+++ b/package_control/package_cleanup.py
@@ -152,7 +152,7 @@ class PackageCleanup(threading.Thread):
 
             clean_old_files(package_dir)
 
-            if os.path.exists(package_dir + '/config.sublime-package-override' ):
+            if os.path.exists(package_dir + '/.sublime-package-override' ):
                 found = False
 
             # Cleanup packages/dependencies that could not be removed due to in-use files

--- a/package_control/package_cleanup.py
+++ b/package_control/package_cleanup.py
@@ -152,7 +152,7 @@ class PackageCleanup(threading.Thread):
 
             clean_old_files(package_dir)
 
-            if os.path.exists(package_dir + '/.sublime-package-override' ):
+            if int(sublime.version()) > 3000 and os.path.exists(package_dir + '/.sublime-package-override'):
                 found = False
 
             # Cleanup packages/dependencies that could not be removed due to in-use files

--- a/package_control/package_cleanup.py
+++ b/package_control/package_cleanup.py
@@ -152,6 +152,9 @@ class PackageCleanup(threading.Thread):
 
             clean_old_files(package_dir)
 
+            if os.path.exists(package_dir + '/config.sublime-package-override' ):
+                found = False
+
             # Cleanup packages/dependencies that could not be removed due to in-use files
             cleanup_file = os.path.join(package_dir, 'package-control.cleanup')
             if os.path.exists(cleanup_file):


### PR DESCRIPTION
When the exists the file `config.sublime-package-override`, the
package control attempts to install the package to `Installed
Packages`, instead of mark the package as installed.

See the issue: #1155
