### PR TITLE
Temporary fix for CERTIFICATE_VERIFY_FAILED

### DIFF
--- a/package_control/download_manager.py
+++ b/package_control/download_manager.py
@@ -224,7 +224,7 @@ class DownloadManager(object):
             'downloader_precedence',
             {
                 "windows": ["wininet"],
-                "osx": ["urllib"],
+                "osx": ["curl", "urllib"],
                 "linux": ["urllib", "curl", "wget"]
             }
         )


### PR DESCRIPTION
This is a temporary fix to the SSL connection errors - curl is able to handle the HTTPS connection fine, while urllib attempts to use a different CA key, which returns invalid.