### PR TITLE
Fix #1137 'ignore_vcs_packages' doesn't work for Git submodules

### DIFF
--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -282,7 +282,7 @@ class PackageManager():
         """
 
         git_dir = os.path.join(self.get_package_dir(package), '.git')
-        return os.path.exists(git_dir) and os.path.isdir(git_dir)
+        return os.path.exists(git_dir) and (os.path.isdir(git_dir) or os.path.isfile(git_dir))
 
     def _is_hg_package(self, package):
         """


### PR DESCRIPTION
Git repositories have a .git folder, submodules have a regular .git file.