### PR TITLE
Error message flood fix

### DIFF
--- a/package_control/show_error.py
+++ b/package_control/show_error.py
@@ -1,4 +1,10 @@
-import sublime
+
+try:
+    # Allow using this file on the website where the sublime
+    # module is unavailable
+    import sublime
+except (ImportError):
+    sublime = None
 
 from . import text
 from .console_write import console_write
@@ -31,22 +37,27 @@ def show_error(string, params=None, strip=True, indent=None):
     global is_error_recentely_displayed
     string = text.format(string, params, strip=strip, indent=indent)
 
-    if is_error_recentely_displayed:
-        console_write( string )
+    if sublime:
+
+        if is_error_recentely_displayed:
+            console_write( string )
+        else:
+            sublime.error_message(u'Package Control\n\n%s\n%s' % (
+                string,
+                u'''
+                    If there will be new error messages on the next seconds,
+                    they will be show on the Sublime Text console
+                '''
+                ) )
+
+            is_error_recentely_displayed = True
+
+            # Enable the message dialog after x.x seconds
+            thread = Timer(60.0, _restart_error_messages)
+            thread.start()
+
     else:
-        sublime.error_message(u'Package Control\n\n%s\n%s' % (
-            string,
-            u'''
-                If there will be new error messages on the next seconds,
-                they will be show on the Sublime Text console
-            '''
-            ) )
-
-        is_error_recentely_displayed = True
-
-        # Enable the message dialog after x.x seconds
-        thread = Timer(60.0, _restart_error_messages)
-        thread.start()
+        console_write( string )
 
 def _restart_error_messages():
     global is_error_recentely_displayed

--- a/package_control/show_error.py
+++ b/package_control/show_error.py
@@ -1,7 +1,14 @@
 import sublime
 
 from . import text
+from .console_write import console_write
 
+from threading import Timer
+
+# When there is a batch performance for some chain of execution, and there are error on them,
+# we cannot show a error message dialog for each one of them immediately, otherwise we would
+# flood the user with messages. See: https://github.com/SublimeTextIssues/Core/issues/1510
+is_error_recentely_displayed = False
 
 def show_error(string, params=None, strip=True, indent=None):
     """
@@ -21,5 +28,19 @@ def show_error(string, params=None, strip=True, indent=None):
         If all lines should be indented by a set indent after being dedented
     """
 
+    global is_error_recentely_displayed
     string = text.format(string, params, strip=strip, indent=indent)
-    sublime.error_message(u'Package Control\n\n%s' % string)
+
+    if is_error_recentely_displayed:
+        console_write( string )
+    else:
+        sublime.error_message(u'Package Control\n\n%s' % string)
+        is_error_recentely_displayed = True
+
+        # Enable the message dialog after x.x seconds
+        thread = Timer(60.0, _restart_error_messages)
+        thread.start()
+
+def _restart_error_messages():
+    global is_error_recentely_displayed
+    is_error_recentely_displayed = False

--- a/package_control/show_error.py
+++ b/package_control/show_error.py
@@ -34,7 +34,14 @@ def show_error(string, params=None, strip=True, indent=None):
     if is_error_recentely_displayed:
         console_write( string )
     else:
-        sublime.error_message(u'Package Control\n\n%s' % string)
+        sublime.error_message(u'Package Control\n\n%s\n%s' % (
+            string,
+            u'''
+                If there will be new error messages on the next seconds,
+                they will be show on the Sublime Text console
+            '''
+            ) )
+
         is_error_recentely_displayed = True
 
         # Enable the message dialog after x.x seconds


### PR DESCRIPTION
When there is a batch performance for some chain of execution, and there are error on them,
we cannot show a error message dialog for each one of them immediately, otherwise we would
flood the user with messages. 

See:

1. https://github.com/SublimeTextIssues/Core/issues/1510 Sublime Text Files syntax error flooding