### PR TITLE
Fix installing local dependencies containing loader.py

### DIFF
--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -268,7 +268,7 @@ class PackageManager():
         if is_py_loader or is_code_loader:
             loader_path = loader_code_path if is_code_loader else loader_py_path
             with open(loader_path, 'rb') as f:
-                code = f.read()
+                code = f.read().decode('utf-8')
 
         return (priority, code)
 


### PR DESCRIPTION
This fixes #1242 by adjusting the code in package_manager.py to decode
the loaded contents of loader.py or loader.code to utf-8 prior to
returning it back to the caller.

This mimics what happens in loader.py in the _existing_info function,
which also potentially returns the loader code after loading it in the
same manner and doing a decode to utf-8 prior to return as well.