### PR TITLE
Fix skip cleanup user dir

### DIFF
--- a/package_control/package_cleanup.py
+++ b/package_control/package_cleanup.py
@@ -1,6 +1,7 @@
 import threading
 import os
 import functools
+import sys
 
 import sublime
 
@@ -148,6 +149,11 @@ class PackageCleanup(threading.Thread):
 
             package_dir = os.path.join(sublime.packages_path(), package_name)
             if not os.path.isdir(package_dir):
+                continue
+
+            # Skipping user package
+            if package_name == "User":
+                console_write("Skip cleanup " + package_dir)
                 continue
 
             clean_old_files(package_dir)

--- a/package_control/package_cleanup.py
+++ b/package_control/package_cleanup.py
@@ -1,7 +1,6 @@
 import threading
 import os
 import functools
-import sys
 
 import sublime
 


### PR DESCRIPTION
My custom plugin or menu that written in Package/User directory always deleted when package_cleanup is running because is not listed as 'installed', I write code to fix by skipping 'User' package/dir.
I'm using windows 10 x64 and SublimeText 3