### PR TITLE
Use sublime.cache_path() to store cache data

### DIFF
--- a/package_control/automatic_upgrader.py
+++ b/package_control/automatic_upgrader.py
@@ -64,7 +64,11 @@ class AutomaticUpgrader(threading.Thread):
 
         self.last_run = None
 
-        self.last_run_file = os.path.join(sublime.packages_path(), 'User', 'Package Control.last-run')
+        cache_path = os.path.join(sublime.cache_path(), 'Package Control')
+        if not os.path.isdir(cache_path):
+            os.mkdir(cache_path)
+
+        self.last_run_file = os.path.join(cache_path, 'last-run')
 
         if os.path.isfile(self.last_run_file):
             with open_compat(self.last_run_file) as fobj:

--- a/package_control/automatic_upgrader.py
+++ b/package_control/automatic_upgrader.py
@@ -64,11 +64,15 @@ class AutomaticUpgrader(threading.Thread):
 
         self.last_run = None
 
-        cache_path = os.path.join(sublime.cache_path(), 'Package Control')
+        if int(sublime.version()) < 3000:
+            cache_path = os.path.join(sublime.packages_path(), 'User')
+        else:
+            cache_path = os.path.join(sublime.cache_path(), 'Package Control')
+
         if not os.path.isdir(cache_path):
             os.mkdir(cache_path)
 
-        self.last_run_file = os.path.join(cache_path, 'last-run')
+        self.last_run_file = os.path.join(cache_path, 'Package Control.last-run')
 
         if os.path.isfile(self.last_run_file):
             with open_compat(self.last_run_file) as fobj:

--- a/package_control/ca_certs.py
+++ b/package_control/ca_certs.py
@@ -221,7 +221,11 @@ def ensure_ca_bundle_dir():
     global ca_bundle_dir
 
     if not ca_bundle_dir:
-        ca_bundle_dir = os.path.join(sublime.cache_path(), 'Package Control')
+        if int(sublime.version()) < 3000:
+            ca_bundle_dir = os.path.join(sublime.packages_path(), 'User')
+        else:
+            ca_bundle_dir = os.path.join(sublime.cache_path(), 'Package Control')
+
     if not os.path.isdir(ca_bundle_dir):
         try:
             os.mkdir(ca_bundle_dir)

--- a/package_control/ca_certs.py
+++ b/package_control/ca_certs.py
@@ -213,19 +213,19 @@ def get_system_ca_bundle_path(settings):
 
 def ensure_ca_bundle_dir():
     """
-    Make sure we have a placed to save the merged-ca-bundle and system-ca-bundle
+    Make sure we have a place to save the merged-ca-bundle and system-ca-bundle
     """
 
     # If the sublime module is available, we bind this value at run time
-    # since the sublime.packages_path() is not available at import time
+    # since the sublime.cache_path() is not available at import time
     global ca_bundle_dir
 
     if not ca_bundle_dir:
-        ca_bundle_dir = os.path.join(sublime.packages_path(), 'User')
-    if not os.path.exists(ca_bundle_dir):
+        ca_bundle_dir = os.path.join(sublime.cache_path(), 'Package Control')
+    if not os.path.isdir(ca_bundle_dir):
         try:
             os.mkdir(ca_bundle_dir)
         except PermissionError:
             ca_bundle_dir = '/var/tmp/package_control'
             if not os.path.exists(ca_bundle_dir):
-                 os.mkdir(ca_bundle_dir)
+                os.mkdir(ca_bundle_dir)

--- a/package_control/http_cache.py
+++ b/package_control/http_cache.py
@@ -13,8 +13,15 @@ class HttpCache(object):
     """
 
     def __init__(self, ttl):
-        self.base_path = sublime.cache_path()
-        for folder in ('Package Control', 'http'):
+        if int(sublime.version()) < 3000:
+            # ST2 doesn't know about cache_path()
+            self.base_path = sublime.packages_path()
+            folders = ('User', 'Package Control.cache')
+        else:
+            self.base_path = sublime.cache_path()
+            folders = ('Package Control', 'http')
+
+        for folder in folders:
             self.base_path = os.path.join(self.base_path, folder)
             if not os.path.isdir(self.base_path):
                 os.mkdir(self.base_path)

--- a/package_control/http_cache.py
+++ b/package_control/http_cache.py
@@ -13,9 +13,11 @@ class HttpCache(object):
     """
 
     def __init__(self, ttl):
-        self.base_path = os.path.join(sublime.packages_path(), 'User', 'Package Control.cache')
-        if not os.path.exists(self.base_path):
-            os.mkdir(self.base_path)
+        self.base_path = sublime.cache_path()
+        for folder in ('Package Control', 'http'):
+            self.base_path = os.path.join(self.base_path, folder)
+            if not os.path.isdir(self.base_path):
+                os.mkdir(self.base_path)
         self.clear(int(ttl))
 
     def clear(self, ttl):


### PR DESCRIPTION
closes #1268

This commit moves all 'state' files to Sublime Text's cache folder.

TODO:
1. How to efficiently migrate/cleanup the old folders and files?
2. Keep ST2 compatibility as it doesn't know about `cache_path()`