### PR TITLE
Avoid duplicated file exists checks

### DIFF
--- a/package_control/automatic_upgrader.py
+++ b/package_control/automatic_upgrader.py
@@ -12,6 +12,7 @@ from .show_error import show_error
 from .console_write import console_write
 from .package_installer import PackageInstaller
 from .package_renamer import PackageRenamer
+from .file_not_found_error import FileNotFoundError
 from .open_compat import open_compat, read_compat, write_compat
 from .settings import pc_settings_filename, load_list_setting
 
@@ -66,12 +67,11 @@ class AutomaticUpgrader(threading.Thread):
 
         self.last_run_file = os.path.join(sublime.packages_path(), 'User', 'Package Control.last-run')
 
-        if os.path.isfile(self.last_run_file):
+        try:
             with open_compat(self.last_run_file) as fobj:
-                try:
-                    self.last_run = int(read_compat(fobj))
-                except ValueError:
-                    pass
+                self.last_run = int(read_compat(fobj))
+        except (FileNotFoundError, ValueError):
+            pass
 
     def determine_next_run(self):
         """

--- a/package_control/http_cache.py
+++ b/package_control/http_cache.py
@@ -3,6 +3,7 @@ import time
 
 import sublime
 
+from .file_not_found_error import FileNotFoundError
 from .open_compat import open_compat, read_compat
 
 
@@ -48,13 +49,12 @@ class HttpCache(object):
         :return:
             The (binary) cached value, or False
         """
-
-        cache_file = os.path.join(self.base_path, key)
-        if not os.path.exists(cache_file):
+        try:
+            cache_file = os.path.join(self.base_path, key)
+            with open_compat(cache_file, 'rb') as f:
+                return read_compat(f)
+        except FileNotFoundError:
             return False
-
-        with open_compat(cache_file, 'rb') as f:
-            return read_compat(f)
 
     def has(self, key):
         cache_file = os.path.join(self.base_path, key)

--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -1737,13 +1737,12 @@ class PackageManager():
             The new (string) version of the package
         """
 
-        messages_file = os.path.join(package_dir, 'messages.json')
-        if not os.path.exists(messages_file):
-            return
-
-        messages_fp = open_compat(messages_file, 'r')
         try:
-            message_info = json.loads(read_compat(messages_fp))
+            messages_file = os.path.join(package_dir, 'messages.json')
+            with open_compat(messages_file, 'r') as f:
+                message_info = json.loads(read_compat(f))
+        except (FileNotFoundError):
+            return
         except (ValueError):
             console_write(
                 u'''
@@ -1752,7 +1751,6 @@ class PackageManager():
                 package
             )
             return
-        messages_fp.close()
 
         def read_message(message_path):
             with open_compat(message_path, 'r') as f:


### PR DESCRIPTION
The `open_compat` function calls `os.path.exists()` if a file is opened for reading and raises `FileNotFoundError` in case the file does not exist.

Therefore external calls to `os.path.exists` cause a file to be checked twice if it exists.

This commit therefore encapsulates all reading operations into `try..except` statements and catches the `FileNotFoundError` to handle it if required.

Furthermore this commit fixes an issue with file pointer to `messages.json` not being closed if `ValueError` is raised while parsing.