### PR TITLE
Fix: No error for invalid dependencies not displayed

### DIFF
--- a/package_control/package_cleanup.py
+++ b/package_control/package_cleanup.py
@@ -265,15 +265,14 @@ class PackageCleanup(threading.Thread):
                 continue
 
             metadata = self.manager.get_metadata(package)
-            if metadata:
-                if not self.is_compatible(metadata):
-                    invalid_packages.append(package)
+            if metadata and not self.is_compatible(metadata)
+                invalid_packages.append(package)
 
         # Make sure installed dependencies are not improperly installed
         for dependency in found_dependencies:
             metadata = self.manager.get_metadata(dependency, is_dependency=True)
             if metadata and not self.is_compatible(metadata):
-                invalid_dependencies.append(package)
+                invalid_dependencies.append(dependency)
 
         if invalid_packages or invalid_dependencies:
             def show_sync_error():

--- a/package_control/package_cleanup.py
+++ b/package_control/package_cleanup.py
@@ -265,7 +265,7 @@ class PackageCleanup(threading.Thread):
                 continue
 
             metadata = self.manager.get_metadata(package)
-            if metadata and not self.is_compatible(metadata)
+            if metadata and not self.is_compatible(metadata):
                 invalid_packages.append(package)
 
         # Make sure installed dependencies are not improperly installed


### PR DESCRIPTION
If invalid dependencies are found, they are not added to the list of `invalid_dependencies` and therefore no error message is created.