### PR TITLE
Avoid duplicated directory exists checks.

### DIFF
--- a/package_control/bootstrap.py
+++ b/package_control/bootstrap.py
@@ -166,12 +166,10 @@ def bootstrap_dependency(settings, url, hash_, priority, version, on_complete):
         dest = path.join(package_dir, dest)
 
         if dest[-1] == '/':
-            if not path.exists(dest):
-                os.makedirs(dest, 0o755)
+            os.makedirs(dest, 0o755, True)
         else:
             dest_dir = path.dirname(dest)
-            if not path.exists(dest_dir):
-                os.makedirs(dest_dir, 0o755)
+            os.makedirs(dest_dir, 0o755, True)
 
             with open(dest, 'wb') as f:
                 f.write(data_zip.read(zip_path))

--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -1355,13 +1355,11 @@ class PackageManager():
                             break
 
                 if path.endswith('/'):
-                    if not os.path.exists(dest):
-                        os.makedirs(dest)
+                    os.makedirs(dest, exist_ok=True)
                     add_extracted_dirs(dest)
                 else:
                     dest_dir = os.path.dirname(dest)
-                    if not os.path.exists(dest_dir):
-                        os.makedirs(dest_dir)
+                    os.makedirs(dest_dir, exist_ok=True)
                     add_extracted_dirs(dest_dir)
                     extracted_paths.append(dest)
                     try:
@@ -1683,8 +1681,7 @@ class PackageManager():
             backup_dir = os.path.join(os.path.dirname(
                 self.settings['packages_path']), 'Backup',
                 datetime.datetime.now().strftime('%Y%m%d%H%M%S'))
-            if not os.path.exists(backup_dir):
-                os.makedirs(backup_dir)
+            os.makedirs(backup_dir, exist_ok=True)
             package_backup_dir = os.path.join(backup_dir, package_name)
             if os.path.exists(package_backup_dir):
                 console_write(


### PR DESCRIPTION
The `os.makedirs()` function raises an OSError by default if the path already exists.
By passing `exist_ok=True` the function fails silently in such cases and can therefore be directly used to optionally create directories.