### PR TITLE
Output Package Control Messages without empty whitespace

### DIFF
--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -1754,7 +1754,10 @@ class PackageManager():
 
         def read_message(message_path):
             with open_compat(message_path, 'r') as f:
-                return '\n  %s\n' % read_compat(f).rstrip().replace('\n', '\n  ')
+                message = read_compat(f).rstrip().replace('\n', '\n  ')
+                if message == ''
+                    return '\n\n'
+                return '\n  %s\n' % message
 
         output = ''
         if not is_upgrade and message_info.get('install'):


### PR DESCRIPTION
This pull request changes the way "Package Control Messages" are displayed, it avoids outputting whitespace when displaying blank newlines.

If you are using the [Trailing Spaces](https://github.com/SublimeText/TrailingSpaces) package, you will see this:

<img width="505" alt="screen shot 2018-05-10 at 23 52 41" src="https://user-images.githubusercontent.com/2276355/39896932-824ae130-54b0-11e8-9fce-30223d78f846.png">
