### PR TITLE
Allow dependencies to specify their own dependencies.

### DIFF
--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -1047,12 +1047,11 @@ class PackageManager():
         release = packages[package_name]['releases'][0]
 
         have_installed_dependencies = False
-        if not is_dependency:
-            dependencies = release.get('dependencies', [])
-            if dependencies:
-                if not self.install_dependencies(dependencies):
-                    return False
-                have_installed_dependencies = True
+        dependencies = release.get('dependencies', [])
+        if dependencies:
+            if not self.install_dependencies(dependencies):
+                return False
+            have_installed_dependencies = True
 
         url = release['url']
         package_filename = package_name + '.sublime-package'


### PR DESCRIPTION
For #1391.

The core change here is so small and self-contained that I think it can/should be done before worrying about broader issues like automatic load order or moving the dependency directory. While this change doesn't fix everything, it will be useful right away.