### PR TITLE
Output Package Control Messages without empty whitespace

### DIFF
--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -1755,7 +1755,7 @@ class PackageManager():
         def read_message(message_path):
             with open_compat(message_path, 'r') as f:
                 lines = read_compat(f).rstrip().split('\n')
-                return '\n' + '\n'.join(list(map(lambda s: '  ' + s if s else '', lines)))
+                return '\n' + '\n'.join(['  ' + s if s else '' for s in lines])
 
         output = ''
         if not is_upgrade and message_info.get('install'):

--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -1754,7 +1754,8 @@ class PackageManager():
 
         def read_message(message_path):
             with open_compat(message_path, 'r') as f:
-                return '\n  %s\n' % read_compat(f).rstrip().replace('\n', '\n  ')
+                lines = read_compat(f).rstrip().split('\n')
+                return '\n' + '\n'.join(list(map(lambda s: '  ' + s if s else '', lines)))
 
         output = ''
         if not is_upgrade and message_info.get('install'):

--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -1755,7 +1755,7 @@ class PackageManager():
         def read_message(message_path):
             with open_compat(message_path, 'r') as f:
                 lines = read_compat(f).rstrip().split('\n')
-                return '\n' + '\n'.join(['  ' + s if s else '' for s in lines])
+                return '\n' + '\n'.join('  ' + s if s else '' for s in lines)
 
         output = ''
         if not is_upgrade and message_info.get('install'):


### PR DESCRIPTION
This pull request changes the way "Package Control Messages" are displayed, it avoids outputting whitespace when displaying blank newlines.

If the [Trailing Spaces](https://github.com/SublimeText/TrailingSpaces) package is installed you can see the before and after:

![PixelSnap 2019-10-11 at 23 09 33@2x](https://user-images.githubusercontent.com/2276355/66685863-ef37f600-ec7d-11e9-8cb0-2a538d6dfdef.png)
