### PR TITLE
Fix n² directory checks during package installation

### DIFF
--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -1292,8 +1292,9 @@ class PackageManager():
 
             # Here we don't use .extractall() since it was having issues on OS X
             overwrite_failed = False
-            extracted_paths = []
-            for path in package_zip.namelist():
+            extracted_paths = set()
+            for info in package_zip.infolist():
+                path = info.filename
                 dest = path
 
                 try:
@@ -1349,7 +1350,7 @@ class PackageManager():
 
                 def add_extracted_dirs(dir_):
                     while dir_ not in extracted_paths:
-                        extracted_paths.append(dir_)
+                        extracted_paths.add(dir_)
                         dir_ = os.path.dirname(dir_)
                         if dir_ == package_dir:
                             break
@@ -1363,7 +1364,7 @@ class PackageManager():
                     if not os.path.exists(dest_dir):
                         os.makedirs(dest_dir)
                     add_extracted_dirs(dest_dir)
-                    extracted_paths.append(dest)
+                    extracted_paths.add(dest)
                     try:
                         with open_compat(dest, 'wb') as f:
                             f.write(package_zip.read(path))


### PR DESCRIPTION
Dramatically improves install times for packages with large amounts of
files. Takes it from 1+ hours to <1 minute.