### PR TITLE
[MacOS] Big Sure Dynamic Library Fixes

### DIFF
--- a/package_control/deps/oscrypto/_mac/_core_foundation_ctypes.py
+++ b/package_control/deps/oscrypto/_mac/_core_foundation_ctypes.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 from __future__ import unicode_literals, division, absolute_import, print_function
 
+import platform
 from ctypes.util import find_library
 from ctypes import c_void_p, c_long, c_uint32, c_char_p, c_byte, c_ulong, c_bool
 from ctypes import CDLL, string_at, cast, POINTER, byref
@@ -15,10 +16,15 @@ __all__ = [
     'CoreFoundation',
 ]
 
+version = platform.mac_ver()[0]
+version_info = tuple(map(int, version.split('.')))
 
-core_foundation_path = find_library('CoreFoundation')
-if not core_foundation_path:
-    raise LibraryNotFoundError('The library CoreFoundation could not be found')
+if version_info >= (10, 16):
+    core_foundation_path =  "/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation"
+else:
+    core_foundation_path = find_library('CoreFoundation')
+    if not core_foundation_path:
+        raise LibraryNotFoundError('The library CoreFoundation could not be found')
 
 CoreFoundation = CDLL(core_foundation_path, use_errno=True)
 

--- a/package_control/deps/oscrypto/_mac/_core_foundation_ctypes.py
+++ b/package_control/deps/oscrypto/_mac/_core_foundation_ctypes.py
@@ -20,7 +20,7 @@ version = platform.mac_ver()[0]
 version_info = tuple(map(int, version.split('.')))
 
 if version_info >= (10, 16):
-    core_foundation_path =  "/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation"
+    core_foundation_path =  "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
 else:
     core_foundation_path = find_library('CoreFoundation')
     if not core_foundation_path:

--- a/package_control/deps/oscrypto/_mac/_security_ctypes.py
+++ b/package_control/deps/oscrypto/_mac/_security_ctypes.py
@@ -23,9 +23,12 @@ version_info = tuple(map(int, version.split('.')))
 if version_info < (10, 7):
     raise OSError('Only OS X 10.7 and newer are supported, not %s.%s' % (version_info[0], version_info[1]))
 
-security_path = find_library('Security')
-if not security_path:
-    raise LibraryNotFoundError('The library Security could not be found')
+if version_info >= (10, 16):
+    security_path = "/System/Library/Frameworks/Security.framework/Versions/A/Security"
+else:
+    security_path = find_library('Security')
+    if not security_path:
+        raise LibraryNotFoundError('The library Security could not be found')
 
 Security = CDLL(security_path, use_errno=True)
 

--- a/package_control/deps/oscrypto/_mac/_security_ctypes.py
+++ b/package_control/deps/oscrypto/_mac/_security_ctypes.py
@@ -24,7 +24,7 @@ if version_info < (10, 7):
     raise OSError('Only OS X 10.7 and newer are supported, not %s.%s' % (version_info[0], version_info[1]))
 
 if version_info >= (10, 16):
-    security_path = "/System/Library/Frameworks/Security.framework/Versions/A/Security"
+    security_path = "/System/Library/Frameworks/Security.framework/Security"
 else:
     security_path = find_library('Security')
     if not security_path:


### PR DESCRIPTION
### Problem

If MacOS version 10.16+ (Big Sur), use hardcoded paths for CoreFoundations and Security due to library changes.

https://developer.apple.com/documentation/macos-release-notes/macos-big-sur-11-beta-release-notes

### Solution

Detection MacOS version `10.16+` and use hardcoded paths, else utilize `find_library` to locate required files

fixes #1475 