### PR TITLE
bumping to the latest commit to oscrypto for Big Sur support

### DIFF
--- a/package_control/deps/oscrypto/_ffi.py
+++ b/package_control/deps/oscrypto/_ffi.py
@@ -7,6 +7,9 @@ Exceptions and compatibility shims for consistently using ctypes and cffi
 from __future__ import unicode_literals, division, absolute_import, print_function
 
 import sys
+import platform
+
+from ctypes.util import find_library
 
 from . import ffi
 from ._types import str_cls, byte_cls, int_types, bytes_to_list
@@ -26,6 +29,7 @@ __all__ = [
     'deref',
     'errno',
     'FFIEngineError',
+    'get_library',
     'is_null',
     'native',
     'new',
@@ -384,6 +388,35 @@ else:
         return getattr(library, signature_type)(func)
 
     engine = 'ctypes'
+
+
+def get_library(name, dylib_name, version):
+    """
+    Retrieve the C library path with special handling for macOS.
+
+    :param name:
+        The library to search the system for.
+    :param dylib_name:
+        The expected unversioned dylib name.
+    :param version:
+        dylib version override.
+        Preferred for macOS 15.15+
+        and used as a fallback for 10.16 where `find_library` doesn't work.
+    :return:
+        Path to the library.
+    """
+    library = find_library(name)
+    if sys.platform == 'darwin':
+        unversioned = '/usr/lib/%s' % dylib_name
+        versioned = unversioned.replace('.dylib', '.%s.dylib' % version)
+        mac_ver = tuple(map(int, platform.mac_ver()[0].split('.')))
+        if not library and mac_ver >= (10, 16):
+            # On macOS 10.16+, find_library doesn't work, so we set a static path
+            library = versioned
+        elif mac_ver >= (10, 15) and library == unversioned:
+            # On macOS 10.15+, we want to strongly version since unversioned libcrypto has a non-stable ABI
+            library = versioned
+    return library
 
 
 class FFIEngineError(Exception):

--- a/package_control/deps/oscrypto/_mac/_common_crypto_ctypes.py
+++ b/package_control/deps/oscrypto/_mac/_common_crypto_ctypes.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals, division, absolute_import, print_functi
 from ctypes import CDLL, c_uint32, c_char_p, c_size_t, c_int, c_uint
 
 from .._ffi import FFIEngineError
-from ..errors import LibraryNotFoundError
 
 
 __all__ = [
@@ -13,8 +12,6 @@ __all__ = [
 
 
 common_crypto_path = '/usr/lib/system/libcommonCrypto.dylib'
-if not common_crypto_path:
-    raise LibraryNotFoundError('The library libcommonCrypto could not be found')
 
 CommonCrypto = CDLL(common_crypto_path, use_errno=True)
 

--- a/package_control/deps/oscrypto/_mac/_core_foundation_ctypes.py
+++ b/package_control/deps/oscrypto/_mac/_core_foundation_ctypes.py
@@ -1,13 +1,11 @@
 # coding: utf-8
 from __future__ import unicode_literals, division, absolute_import, print_function
 
-from ctypes.util import find_library
 from ctypes import c_void_p, c_long, c_uint32, c_char_p, c_byte, c_ulong, c_bool
 from ctypes import CDLL, string_at, cast, POINTER, byref
 import ctypes
 
 from .._ffi import FFIEngineError, buffer_from_bytes, byte_string_from_buffer
-from ..errors import LibraryNotFoundError
 
 
 __all__ = [
@@ -16,9 +14,7 @@ __all__ = [
 ]
 
 
-core_foundation_path = find_library('CoreFoundation')
-if not core_foundation_path:
-    raise LibraryNotFoundError('The library CoreFoundation could not be found')
+core_foundation_path = '/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation'
 
 CoreFoundation = CDLL(core_foundation_path, use_errno=True)
 

--- a/package_control/deps/oscrypto/_mac/_security_ctypes.py
+++ b/package_control/deps/oscrypto/_mac/_security_ctypes.py
@@ -2,12 +2,10 @@
 from __future__ import unicode_literals, division, absolute_import, print_function
 
 import platform
-from ctypes.util import find_library
 from ctypes import c_void_p, c_int32, c_char_p, c_size_t, c_byte, c_int, c_uint32, c_uint64, c_ulong, c_long, c_bool
 from ctypes import CDLL, POINTER, CFUNCTYPE, Structure
 
 from .._ffi import FFIEngineError
-from ..errors import LibraryNotFoundError
 
 
 __all__ = [
@@ -18,14 +16,12 @@ __all__ = [
 
 
 version = platform.mac_ver()[0]
-version_info = tuple(map(int, version.split('.')))
+version_info = tuple(map(int,  platform.mac_ver()[0].split('.')))
 
 if version_info < (10, 7):
     raise OSError('Only OS X 10.7 and newer are supported, not %s.%s' % (version_info[0], version_info[1]))
 
-security_path = find_library('Security')
-if not security_path:
-    raise LibraryNotFoundError('The library Security could not be found')
+security_path = '/System/Library/Frameworks/Security.framework/Security'
 
 Security = CDLL(security_path, use_errno=True)
 

--- a/package_control/deps/oscrypto/_openssl/_libcrypto_ctypes.py
+++ b/package_control/deps/oscrypto/_openssl/_libcrypto_ctypes.py
@@ -1,15 +1,13 @@
 # coding: utf-8
 from __future__ import unicode_literals, division, absolute_import, print_function
 
-import platform
 import re
-import sys
-from ctypes.util import find_library
+
 from ctypes import CDLL, c_void_p, c_char_p, c_int, c_ulong, c_uint, c_long, c_size_t, POINTER
 
 from .. import _backend_config
 from .._errors import pretty_message
-from .._ffi import FFIEngineError
+from .._ffi import FFIEngineError, get_library
 from ..errors import LibraryNotFoundError
 
 
@@ -25,12 +23,7 @@ __all__ = [
 
 libcrypto_path = _backend_config().get('libcrypto_path')
 if libcrypto_path is None:
-    libcrypto_path = find_library('crypto')
-    # if we are on catalina, we want to strongly version libcrypto since unversioned libcrypto has a non-stable ABI
-    if sys.platform == 'darwin' and platform.mac_ver()[0].startswith('10.15') and \
-            libcrypto_path.endswith('libcrypto.dylib'):
-        # libcrypto.42.dylib is in libressl-2.6 which as a OpenSSL 1.0.1-compatible API
-        libcrypto_path = libcrypto_path.replace('libcrypto.dylib', 'libcrypto.42.dylib')
+    libcrypto_path = get_library('crypto', 'libcrypto.dylib', '42')
 if not libcrypto_path:
     raise LibraryNotFoundError('The library libcrypto could not be found')
 

--- a/package_control/deps/oscrypto/_openssl/_libssl_ctypes.py
+++ b/package_control/deps/oscrypto/_openssl/_libssl_ctypes.py
@@ -1,13 +1,10 @@
 # coding: utf-8
 from __future__ import unicode_literals, division, absolute_import, print_function
 
-import platform
-import sys
-from ctypes.util import find_library
 from ctypes import CDLL, CFUNCTYPE, POINTER, c_void_p, c_char_p, c_int, c_size_t, c_long
 
 from .. import _backend_config
-from .._ffi import FFIEngineError
+from .._ffi import FFIEngineError, get_library
 from ..errors import LibraryNotFoundError
 from ._libcrypto import libcrypto_version_info
 
@@ -19,11 +16,7 @@ __all__ = [
 
 libssl_path = _backend_config().get('libssl_path')
 if libssl_path is None:
-    libssl_path = find_library('ssl')
-    # if we are on catalina, we want to strongly version libssl since unversioned libcrypto has a non-stable ABI
-    if sys.platform == 'darwin' and platform.mac_ver()[0].startswith('10.15') and libssl_path.endswith('libssl.dylib'):
-        # libssl.44.dylib is in libressl-2.6 which as a OpenSSL 1.0.1-compatible API
-        libssl_path = libssl_path.replace('libssl.dylib', 'libssl.44.dylib')
+    libssl_path = get_library('ssl', 'libssl', '44')
 if not libssl_path:
     raise LibraryNotFoundError('The library libssl could not be found')
 

--- a/package_control/deps/oscrypto/_openssl/tls.py
+++ b/package_control/deps/oscrypto/_openssl/tls.py
@@ -749,6 +749,10 @@ class TLSSocket(object):
                 # Handle ECONNRESET and EPIPE
                 if e.errno == 104 or e.errno == 32:
                     raise_disconnect = True
+                # Handle EPROTOTYPE. Newer versions of macOS will return this
+                # if we try to call send() while the socket is being torn down
+                elif sys.platform == 'darwin' and e.errno == 41:
+                    raise_disconnect = True
                 else:
                     raise
 

--- a/package_control/deps/oscrypto/version.py
+++ b/package_control/deps/oscrypto/version.py
@@ -2,5 +2,5 @@
 from __future__ import unicode_literals, division, absolute_import, print_function
 
 
-__version__ = '1.2.0.dev1'
-__version_info__ = (1, 2, 0, 'dev1')
+__version__ = '1.2.0'
+__version_info__ = (1, 2, 0)


### PR DESCRIPTION
Note: Big Sur broken the `find_library` function of the ctypes library due to having libraries in cache vs on physical disk. Thus, `find_library` isn't able to locate the libraries because they are all in cache.


Fixes #1475 