### PR TITLE
Fix QuickPanelItem usages

### DIFF
--- a/package_control/commands/list_packages_command.py
+++ b/package_control/commands/list_packages_command.py
@@ -9,6 +9,8 @@ from ..show_quick_panel import show_quick_panel
 from ..package_manager import PackageManager
 from .existing_packages_command import ExistingPackagesCommand
 
+USE_QUICK_PANEL_ITEM = hasattr(sublime, 'QuickPanelItem')
+
 
 class ListPackagesCommand(sublime_plugin.WindowCommand):
 
@@ -78,7 +80,11 @@ class ListPackagesThread(threading.Thread, ExistingPackagesCommand):
 
         if picked == -1:
             return
-        package_name = self.package_list[picked][0]
+
+        if USE_QUICK_PANEL_ITEM:
+            package_name = self.package_list[picked].trigger
+        else:
+            package_name = self.package_list[picked][0]
 
         def open_dir():
             package_dir = self.manager.get_package_dir(package_name)

--- a/package_control/commands/remove_package_command.py
+++ b/package_control/commands/remove_package_command.py
@@ -11,6 +11,8 @@ from ..thread_progress import ThreadProgress
 from ..package_disabler import PackageDisabler
 from ..package_manager import PackageManager
 
+USE_QUICK_PANEL_ITEM = hasattr(sublime, 'QuickPanelItem')
+
 
 class RemovePackageCommand(sublime_plugin.WindowCommand, ExistingPackagesCommand, PackageDisabler):
 
@@ -53,16 +55,20 @@ class RemovePackageCommand(sublime_plugin.WindowCommand, ExistingPackagesCommand
 
         if picked == -1:
             return
-        package = self.package_list[picked][0]
 
-        self.disable_packages(package, 'remove')
+        if USE_QUICK_PANEL_ITEM:
+            package_name = self.package_list[picked].trigger
+        else:
+            package_name = self.package_list[picked][0]
 
-        thread = RemovePackageThread(self.manager, package)
+        self.disable_packages(package_name, 'remove')
+
+        thread = RemovePackageThread(self.manager, package_name)
         thread.start()
         ThreadProgress(
             thread,
-            'Removing package %s' % package,
-            'Package %s successfully removed' % package
+            'Removing package %s' % package_name,
+            'Package %s successfully removed' % package_name
         )
 
 

--- a/package_control/package_installer.py
+++ b/package_control/package_installer.py
@@ -9,8 +9,7 @@ from .package_manager import PackageManager
 from .package_disabler import PackageDisabler
 from .versions import version_comparable
 
-
-USE_QUICK_PANEL_ITEM = int(sublime.version()) > 4080
+USE_QUICK_PANEL_ITEM = hasattr(sublime, 'QuickPanelItem')
 
 
 class PackageInstaller(PackageDisabler):


### PR DESCRIPTION
This commit fixes a regression with several commands which use quick panel items' labels, which were broken by commit d22abdbab4e7a6f071b485f5ec49319abb986c12.