### PR TITLE
Handle redirects with urllib

### DIFF
--- a/package_control/downloaders/urllib_downloader.py
+++ b/package_control/downloaders/urllib_downloader.py
@@ -10,6 +10,7 @@ try:
     from urllib.request import (
         build_opener,
         HTTPPasswordMgrWithDefaultRealm,
+        HTTPRedirectHandler,
         ProxyBasicAuthHandler,
         ProxyDigestAuthHandler,
         ProxyHandler,
@@ -292,7 +293,7 @@ class UrlLibDownloader(DecodingDownloader, LimitingDownloader, CachingDownloader
                 if https_proxy:
                     password_manager.add_password(None, https_proxy, proxy_username, proxy_password)
 
-            handlers = [proxy_handler]
+            handlers = [HTTPRedirectHandler(), proxy_handler]
 
             basic_auth_handler = ProxyBasicAuthHandler(password_manager)
             digest_auth_handler = ProxyDigestAuthHandler(password_manager)


### PR DESCRIPTION
close #1416

Tested as follows: in the ST console run:

```
import sys
pc=sys.modules["Package Control"]
downloader=pc.package_control.downloaders.UrlLibDownloader({"cache_length": 1, "debug": False, "timeout": 100, "user_agent": "Hello there general kenobi"})
content=downloader.download("https://github.com/sublimelsp/LSP-lua/releases/download/v0.0.4/LSP-lua_osx-x64.zip", "oops", 100, 1)
import os
os.makedirs(os.path.join(sublime.packages_path(), "User", "Downloads"), exist_ok=True)
fp=open(os.path.join(sublime.packages_path(), "User", "Downloads", "asdf.zip"), "wb")
fp.write(content)
fp.close()
```

It looks like the oscrypto backend as well as the WinINet backend handles redirect, judging from skimming through the code.