### PR TITLE
Fix github unit tests

### DIFF
--- a/package_control/tests/__init__.py
+++ b/package_control/tests/__init__.py
@@ -5,12 +5,15 @@ import re
 
 import sublime
 
+from .. import __version__
 
 LAST_COMMIT_TIMESTAMP = '2014-11-28 20:54:15'
 LAST_COMMIT_VERSION = re.sub(r'[ :\-]', '.', LAST_COMMIT_TIMESTAMP)
 
 CLIENT_ID = ''
 CLIENT_SECRET = ''
+
+USER_AGENT = 'Package Control %s Unittests' % __version__
 
 
 class StringQueue():

--- a/package_control/tests/clients.py
+++ b/package_control/tests/clients.py
@@ -6,7 +6,7 @@ from ..clients.gitlab_client import GitLabClient
 from ..clients.bitbucket_client import BitBucketClient
 from ..http_cache import HttpCache
 
-from . import LAST_COMMIT_TIMESTAMP, LAST_COMMIT_VERSION, CLIENT_ID, CLIENT_SECRET
+from . import LAST_COMMIT_TIMESTAMP, LAST_COMMIT_VERSION, CLIENT_ID, CLIENT_SECRET, USER_AGENT
 
 
 class GitHubClientTests(unittest.TestCase):
@@ -16,6 +16,8 @@ class GitHubClientTests(unittest.TestCase):
         return {
             'debug': True,
             'cache': HttpCache(604800),
+            'cache_length': 604800,
+            'user_agent': USER_AGENT,
             'query_string_params': {
                 'api.github.com': {
                     'client_id': CLIENT_ID,
@@ -135,6 +137,8 @@ class GitLabClientTests(unittest.TestCase):
         return {
             'debug': True,
             'cache': HttpCache(604800),
+            'cache_length': 604800,
+            'user_agent': USER_AGENT
         }
 
     def test_gitlab_client_repo_info(self):
@@ -250,7 +254,9 @@ class BitBucketClientTests(unittest.TestCase):
     def bitbucket_settings(self):
         return {
             'debug': True,
-            'cache': HttpCache(604800)
+            'cache': HttpCache(604800),
+            'cache_length': 604800,
+            'user_agent': USER_AGENT
         }
 
     def test_bitbucket_client_repo_info(self):

--- a/package_control/tests/providers.py
+++ b/package_control/tests/providers.py
@@ -9,7 +9,7 @@ from ..providers.gitlab_user_provider import GitLabUserProvider
 from ..providers.bitbucket_repository_provider import BitBucketRepositoryProvider
 from ..http_cache import HttpCache
 
-from . import LAST_COMMIT_TIMESTAMP, LAST_COMMIT_VERSION, CLIENT_ID, CLIENT_SECRET
+from . import LAST_COMMIT_TIMESTAMP, LAST_COMMIT_VERSION, CLIENT_ID, CLIENT_SECRET, USER_AGENT
 
 
 class GitHubRepositoryProviderTests(unittest.TestCase):
@@ -19,6 +19,8 @@ class GitHubRepositoryProviderTests(unittest.TestCase):
         return {
             'debug': True,
             'cache': HttpCache(604800),
+            'cache_length': 604800,
+            'user_agent': USER_AGENT,
             'query_string_params': {
                 'api.github.com': {
                     'client_id': CLIENT_ID,
@@ -128,6 +130,8 @@ class GitHubUserProviderTests(unittest.TestCase):
         return {
             'debug': True,
             'cache': HttpCache(604800),
+            'cache_length': 604800,
+            'user_agent': USER_AGENT,
             'query_string_params': {
                 'api.github.com': {
                     'client_id': CLIENT_ID,
@@ -216,6 +220,8 @@ class GitLabRepositoryProviderTests(unittest.TestCase):
         return {
             'debug': True,
             'cache': HttpCache(604800),
+            'cache_length': 604800,
+            'user_agent': USER_AGENT
         }
 
     def test_match_url(self):
@@ -320,6 +326,8 @@ class GitLabUserProviderTests(unittest.TestCase):
         return {
             'debug': True,
             'cache': HttpCache(604800),
+            'cache_length': 604800,
+            'user_agent': USER_AGENT
         }
 
     def test_match_url(self):
@@ -399,7 +407,9 @@ class BitBucketRepositoryProviderTests(unittest.TestCase):
     def bitbucket_settings(self):
         return {
             'debug': True,
-            'cache': HttpCache(604800)
+            'cache': HttpCache(604800),
+            'cache_length': 604800,
+            'user_agent': USER_AGENT
         }
 
     def test_match_url(self):
@@ -499,6 +509,8 @@ class RepositoryProviderTests(unittest.TestCase):
         return {
             'debug': True,
             'cache': HttpCache(604800),
+            'cache_length': 604800,
+            'user_agent': USER_AGENT,
             'query_string_params': {
                 'api.github.com': {
                     'client_id': CLIENT_ID,
@@ -1309,7 +1321,9 @@ class ChannelProviderTests(unittest.TestCase):
     def settings(self):
         return {
             'debug': True,
-            'cache': HttpCache(604800)
+            'cache': HttpCache(604800),
+            'cache_length': 604800,
+            'user_agent': USER_AGENT
         }
 
     def test_get_name_map_12(self):


### PR DESCRIPTION
This PR adds an `user_agent` field to all API requests. It is crucial for api.github.com to work. It returns 403 "forbidden" without it and related tests fail.

Something else recovered from `next` branch from 2017 is the `cache_length` field.