### PR TITLE
Update scheme to 4.0.0

### DIFF
--- a/1_reloader.py
+++ b/1_reloader.py
@@ -30,7 +30,7 @@ mods_load_order = [
 
     '.sys_path',
     '.wheel',
-    '.dependency',
+    '.library',
     '.text',
     '.cache',
     '.http_cache',

--- a/1_reloader.py
+++ b/1_reloader.py
@@ -171,6 +171,7 @@ mods_load_order = [
     '.clients.gitlab_client',
     '.clients.readme_client',
 
+    '.providers.base_repository_provider',
     '.providers.provider_exception',
     '.providers.bitbucket_repository_provider',
     '.providers.github_repository_provider',

--- a/2_bootstrap.py
+++ b/2_bootstrap.py
@@ -6,7 +6,7 @@ from textwrap import dedent
 
 import sublime
 
-from .package_control import sys_path, dependency
+from .package_control import sys_path, library
 from .package_control.console_write import console_write
 from .package_control.package_manager import PackageManager
 from .package_control.settings import (
@@ -103,7 +103,7 @@ def _migrate_loaders(settings):
                 elif os.path.exists(dep_sys_paths['all']):
                     src_dir = dep_sys_paths['all']
 
-                dependency.install(
+                library.install(
                     lib_root,
                     src_dir,
                     name,

--- a/example-channel.json
+++ b/example-channel.json
@@ -2,7 +2,7 @@
 	// BE SURE TO REMOVE THESE COMMENTS BEFORE USING THIS TEMPLATE SINCE
 	// COMMENTS ARE NOT ALLOWED IN JSON
 
-	"schema_version": "3.0.0",
+	"schema_version": "3.1.0",
 
 	// All repositories must be an HTTPS URL. SSL certificates help prevent
 	// unauthorized code being loaded onto users' machines.
@@ -59,7 +59,8 @@
 						"version": "1.0.0",
 						"url": "https://codeload.github.com/codexns/sublime-bz2/zip/1.0.0",
 						"sublime_text": "*",
-						"platforms": ["*"]
+						"platforms": ["*"],
+						"python_versions": ["3.3", "3.8"]
 					}
 				]
 			}

--- a/example-channel.json
+++ b/example-channel.json
@@ -2,7 +2,7 @@
 	// BE SURE TO REMOVE THESE COMMENTS BEFORE USING THIS TEMPLATE SINCE
 	// COMMENTS ARE NOT ALLOWED IN JSON
 
-	"schema_version": "3.1.0",
+	"schema_version": "4.0.0",
 
 	// All repositories must be an HTTPS URL. SSL certificates help prevent
 	// unauthorized code being loaded onto users' machines.
@@ -40,12 +40,11 @@
 		]
 	},
 
-	// The "dependencies_cache" is just like "packages_cache", but for
-	// dependencies
-	"dependencies_cache": {
+	// The "libraries_cache" is just like "packages_cache", but for libraries.
+	"libraries_cache": {
 		"https://packagecontrol.io/packages.json": [
 
-			// Like with packages, dependency info must be fully resolved,
+			// Like with packages, library info must be fully resolved,
 			// which for packages means releases must have "url", "version",
 			// "sublime_text" and "platforms" keys instead of "base" and "tags".
 			{

--- a/example-repository.json
+++ b/example-repository.json
@@ -2,7 +2,7 @@
 	// BE SURE TO REMOVE THESE COMMENTS BEFORE USING THIS TEMPLATE SINCE
 	// COMMENTS ARE NOT ALLOWED IN JSON
 
-	"schema_version": "3.0.0",
+	"schema_version": "3.1.0",
 
 	// Packages can be specified with a simple URL to a GitHub or BitBucket
 	// repository, but details can be overridden for every field. It is also
@@ -388,7 +388,8 @@
 				{
 					"base": "https://github.com/codexns/sublime-bz2",
 					"tags": true,
-					"sublime_text": "*"
+					"sublime_text": "*",
+					"python_versions": ["3.3", "3.8"]
 				}
 			]
 		},
@@ -404,6 +405,7 @@
 					"url": "http://packagecontrol.io/ssl-linux.sublime-package",
 					"sublime_text": "*",
 					"platforms": ["linux"],
+					"python_versions": ["3.3", "3.8"],
 					"sha256": "d12a2ca2843b3c06a834652e9827a29f88872bb31bd64230775f3dbe12e0ebd4"
 				}
 			]
@@ -420,6 +422,7 @@
 					"url": "http://packagecontrol.io/ssl-windows.sublime-package",
 					"sublime_text": "<3000",
 					"platforms": ["windows"],
+					"python_versions": ["3.3", "3.8"],
 					"sha256": "efe25e3bdf2e8f791d86327978aabe093c9597a6ceb8c2fb5438c1d810e02bea"
 				}
 			]

--- a/example-repository.json
+++ b/example-repository.json
@@ -232,14 +232,14 @@
 			]
 		},
 
-		// Mark a release as requiring one or more dependencies
+		// Mark a release as requiring one or more libraries
 		{
 			"details": "https://github.com/wbond/sublime_alignment",
 			"releases": [
 				{
 					"sublime_text": "*",
 					"tags": true,
-					"dependencies": ["bz2"]
+					"libraries": ["bz2"]
 				}
 			]
 		},
@@ -373,7 +373,7 @@
 	// that are supplementary, or missing from Sublime Text.
 	"libraries": [
 		{
-			// Each dependency should have a name, description,
+			// Each library should have a name, description,
 			// author, issues URL and a list of releases. Each release needs a
 			// version and url or base and tags plus sublime_text keys. The
 			// platforms key is optionally and defaults to *. If the URL is not

--- a/example-repository.json
+++ b/example-repository.json
@@ -2,7 +2,7 @@
 	// BE SURE TO REMOVE THESE COMMENTS BEFORE USING THIS TEMPLATE SINCE
 	// COMMENTS ARE NOT ALLOWED IN JSON
 
-	"schema_version": "3.1.0",
+	"schema_version": "4.0.0",
 
 	// Packages can be specified with a simple URL to a GitHub or BitBucket
 	// repository, but details can be overridden for every field. It is also
@@ -368,19 +368,18 @@
 		}
 	],
 
-	// Packages that can be listed under "dependencies" in under "releases" of
+	// Packages that can be listed under "libraries" in under "releases" of
 	// a normal package. These will typically be compiled Python extensions
 	// that are supplementary, or missing from Sublime Text.
-	"dependencies": [
+	"libraries": [
 		{
-			// Each dependency should have a name, load_order, description,
+			// Each dependency should have a name, description,
 			// author, issues URL and a list of releases. Each release needs a
 			// version and url or base and tags plus sublime_text keys. The
 			// platforms key is optionally and defaults to *. If the URL is not
 			// over SSL, there needs to be a sha256 key containing the sha256
 			// hash of the package file.
 			"name": "bz2",
-			"load_order": "02",
 			"description": "Python bz2 module",
 			"author": "wbond",
 			"issues": "https://github.com/codexns/sublime-bz2/issues",
@@ -395,7 +394,6 @@
 		},
 		{
 			"name": "ssl-linux",
-			"load_order": "01",
 			"description": "Python _ssl module for Linux",
 			"author": "wbond",
 			"issues": "https://github.com/codexns/sublime-ssl-linux/issues",
@@ -412,7 +410,6 @@
 		},
 		{
 			"name": "ssl-windows",
-			"load_order": "02",
 			"description": "Python _ssl module for Sublime Text 2 on Windows",
 			"author": "wbond",
 			"issues": "https://github.com/codexns/sublime-ssl-windows/issues",

--- a/package_control/downloaders/wget_downloader.py
+++ b/package_control/downloaders/wget_downloader.py
@@ -1,6 +1,7 @@
 import tempfile
 import re
 import os
+import sys
 
 from ..console_write import console_write
 from .cli_downloader import CliDownloader
@@ -235,7 +236,7 @@ class WgetDownloader(CliDownloader, DecodingDownloader, LimitingDownloader, Cach
             HTTP header names.
         """
 
-        with open(self.tmp_file, 'r') as fobj:
+        with open(self.tmp_file, 'r', encoding=sys.getdefaultencoding()) as fobj:
             output = fobj.read().splitlines()
         self.clean_tmp_file()
 

--- a/package_control/downloaders/wget_downloader.py
+++ b/package_control/downloaders/wget_downloader.py
@@ -104,10 +104,11 @@ class WgetDownloader(CliDownloader, DecodingDownloader, LimitingDownloader, Cach
             bundle_path = get_ca_bundle_path(self.settings)
             command.append('--ca-certificate=' + bundle_path)
 
+        command.append('-S')
         if self.debug:
             command.append('-d')
         else:
-            command.append('-S')
+            command.append('-q')
 
         http_proxy = self.settings.get('http_proxy')
         https_proxy = self.settings.get('https_proxy')
@@ -238,6 +239,7 @@ class WgetDownloader(CliDownloader, DecodingDownloader, LimitingDownloader, Cach
             output = fobj.read().splitlines()
         self.clean_tmp_file()
 
+        debug_missing = False
         error = None
         header_lines = []
         if self.debug:
@@ -246,6 +248,13 @@ class WgetDownloader(CliDownloader, DecodingDownloader, LimitingDownloader, Cach
             for line in output:
                 if section == 'General':
                     if self.skippable_line(line):
+                        continue
+
+                    # This handles situations where debug is not compiled in
+                    if line.startswith('HTTP request sent, awaiting response'):
+                        last_section = 'General'
+                        section = 'Read'
+                        debug_missing = True
                         continue
 
                 # Skip blank lines
@@ -275,7 +284,11 @@ class WgetDownloader(CliDownloader, DecodingDownloader, LimitingDownloader, Cach
                     console_write('Wget HTTP Debug %s', section)
 
                 if section == 'Read':
-                    header_lines.append(line)
+                    if debug_missing:
+                        if ':' in line:
+                            header_lines.append(line.lstrip())
+                    else:
+                        header_lines.append(line)
 
                 console_write('  %s', line, prefix=False)
                 last_section = section

--- a/package_control/library.py
+++ b/package_control/library.py
@@ -7,29 +7,29 @@ from . import wheel
 def install(dest_root, src_dir, name, version, description, url, plat_specific):
     """
     :param dest_root:
-        A unicode path to the directory to install the dependency into. If a
-        dependency has a folder named A, it will be installed to: dest_root/A.
+        A unicode path to the directory to install the library into. If a
+        library has a folder named A, it will be installed to: dest_root/A.
 
     :param src_dir:
         A unicode path to the directory to copy files and folders from. For
         most dependencies, this directory will contain a single folder with
-        the name of the dependency.
+        the name of the library.
 
     :param name:
-        A unicode string of the dependency name
+        A unicode string of the library name
 
     :param version:
         A unicode string of a PEP 440 version
 
     :param description:
-        An optional unicode string of a description of the dependency
+        An optional unicode string of a description of the library
 
     :param url:
-        An optional unicode string of the homepage for the dependency
+        An optional unicode string of the homepage for the library
 
     :param plat_specific:
         A bool indicating if the source files are platform or architecture
-        specific. Typically this would be set if the dependency contains any
+        specific. Typically this would be set if the library contains any
         shared libraries or executables.
     """
 

--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -175,14 +175,14 @@ class PackageManager():
 
     def get_libraries(self, package):
         """
-        Returns a list of dependencies for the specified package on the
+        Returns a list of libraries for the specified package on the
         current machine
 
         :param package:
             The name of the package
 
         :return:
-            A list of dependency names
+            A list of library names
         """
 
         if package_file_exists(package, 'dependencies.json'):

--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -1007,7 +1007,7 @@ class PackageManager():
 
         have_installed_dependencies = False
         if not is_dependency:
-            dependencies = release.get('dependencies', [])
+            dependencies = release.get('libraries', [])
             if dependencies:
                 if not self.install_dependencies(dependencies):
                     return False
@@ -1386,7 +1386,7 @@ class PackageManager():
                     "description": packages[package_name]['description']
                 }
                 if not is_dependency:
-                    metadata['dependencies'] = release.get('dependencies', [])
+                    metadata['dependencies'] = release.get('libraries', [])
                 json.dump(metadata, fobj)
 
             # Submit install and upgrade info

--- a/package_control/providers/base_repository_provider.py
+++ b/package_control/providers/base_repository_provider.py
@@ -1,0 +1,131 @@
+class BaseRepositoryProvider:
+    """
+    Base repository downloader that fetches package info
+
+    This base class acts as interface to ensure all providers expose the same
+    set of methods. All providers should therefore derive from this base class.
+
+    The structure of the JSON a repository should contain is located in
+    example-packages.json.
+
+    :param repo:
+        The URL of the package repository
+
+    :param settings:
+        A dict containing at least the following fields:
+          `cache_length`,
+          `debug`,
+          `timeout`,
+          `user_agent`
+        Optional fields:
+          `http_proxy`,
+          `https_proxy`,
+          `proxy_username`,
+          `proxy_password`,
+          `query_string_params`
+    """
+
+    __slots__ = [
+        'broken_libriaries'
+        'broken_packages',
+        'cache',
+        'failed_sources',
+        'repo',
+        'settings',
+    ]
+
+    def __init__(self, repo, settings):
+        self.broken_libriaries = {}
+        self.broken_packages = {}
+        self.failed_sources = {}
+        self.cache = {}
+        self.repo = repo
+        self.settings = settings
+
+    @classmethod
+    def match_url(cls, repo):
+        """
+        Indicates if this provider can handle the provided repo
+        """
+
+        return True
+
+    def prefetch(self):
+        """
+        Go out and perform HTTP operations, caching the result
+
+        :raises:
+            DownloaderException: when there is an issue download package info
+            ClientException: when there is an issue parsing package info
+        """
+
+        [name for name, info in self.get_packages()]
+
+    def fetch(self):
+        """
+        Retrieves and loads the JSON for other methods to use
+
+        :raises:
+            NotImplementedError: when called
+        """
+
+        raise NotImplementedError()
+
+    def get_broken_libraries(self):
+        """
+        List of library names for libraries that are missing information
+
+        :return:
+            A generator of ("Dependency Name", Exception()) tuples
+        """
+
+        return self.broken_libriaries.items()
+
+    def get_broken_packages(self):
+        """
+        List of package names for packages that are missing information
+
+        :return:
+            A generator of ("Package Name", Exception()) tuples
+        """
+
+        return self.broken_packages.items()
+
+    def get_failed_sources(self):
+        """
+        List of any URLs that could not be accessed while accessing this repository
+
+        :return:
+            A generator of ("https://example.com", Exception()) tuples
+        """
+
+        return self.failed_sources.items()
+
+    def get_libraries(self, invalid_sources=None):
+        """
+        For API-compatibility with RepositoryProvider
+        """
+
+        return {}.items()
+
+    def get_packages(self, invalid_sources=None):
+        """
+        For API-compatibility with RepositoryProvider
+        """
+
+        return {}.items()
+
+    def get_sources(self):
+        """
+        Return a list of current URLs that are directly referenced by the repo
+
+        :return:
+            A list of URLs
+        """
+
+        return [self.repo]
+
+    def get_renamed_packages(self):
+        """For API-compatibility with RepositoryProvider"""
+
+        return {}

--- a/package_control/providers/base_repository_provider.py
+++ b/package_control/providers/base_repository_provider.py
@@ -8,7 +8,7 @@ class BaseRepositoryProvider:
     The structure of the JSON a repository should contain is located in
     example-packages.json.
 
-    :param repo:
+    :param repo_url:
         The URL of the package repository
 
     :param settings:
@@ -30,22 +30,22 @@ class BaseRepositoryProvider:
         'broken_packages',
         'cache',
         'failed_sources',
-        'repo',
+        'repo_url',
         'settings',
     ]
 
-    def __init__(self, repo, settings):
+    def __init__(self, repo_url, settings):
         self.broken_libriaries = {}
         self.broken_packages = {}
         self.failed_sources = {}
         self.cache = {}
-        self.repo = repo
+        self.repo_url = repo_url
         self.settings = settings
 
     @classmethod
-    def match_url(cls, repo):
+    def match_url(cls, repo_url):
         """
-        Indicates if this provider can handle the provided repo
+        Indicates if this provider can handle the provided repo_url
         """
 
         return True
@@ -123,7 +123,7 @@ class BaseRepositoryProvider:
             A list of URLs
         """
 
-        return [self.repo]
+        return [self.repo_url]
 
     def get_renamed_packages(self):
         """For API-compatibility with RepositoryProvider"""

--- a/package_control/providers/base_repository_provider.py
+++ b/package_control/providers/base_repository_provider.py
@@ -76,7 +76,7 @@ class BaseRepositoryProvider:
         List of library names for libraries that are missing information
 
         :return:
-            A generator of ("Dependency Name", Exception()) tuples
+            A generator of ("Library Name", Exception()) tuples
         """
 
         return self.broken_libriaries.items()

--- a/package_control/providers/bitbucket_repository_provider.py
+++ b/package_control/providers/bitbucket_repository_provider.py
@@ -32,10 +32,10 @@ class BitBucketRepositoryProvider(BaseRepositoryProvider):
     """
 
     @classmethod
-    def match_url(cls, repo):
-        """Indicates if this provider can handle the provided repo"""
+    def match_url(cls, repo_url):
+        """Indicates if this provider can handle the provided repo_url"""
 
-        return re.search('^https?://bitbucket.org/([^/]+/[^/]+)/?$', repo) is not None
+        return re.search('^https?://bitbucket.org/([^/]+/[^/]+)/?$', repo_url) is not None
 
     def get_packages(self, invalid_sources=None):
         """
@@ -84,16 +84,16 @@ class BitBucketRepositoryProvider(BaseRepositoryProvider):
                 yield (key, value)
             return
 
-        if invalid_sources is not None and self.repo in invalid_sources:
+        if invalid_sources is not None and self.repo_url in invalid_sources:
             raise StopIteration()
 
         client = BitBucketClient(self.settings)
 
         try:
-            repo_info = client.repo_info(self.repo)
+            repo_info = client.repo_info(self.repo_url)
 
             releases = []
-            for download in client.download_info(self.repo):
+            for download in client.download_info(self.repo_url):
                 download['sublime_text'] = '*'
                 download['platforms'] = ['*']
                 releases.append(download)
@@ -108,7 +108,7 @@ class BitBucketRepositoryProvider(BaseRepositoryProvider):
                 'releases': releases,
                 'previous_names': [],
                 'labels': [],
-                'sources': [self.repo],
+                'sources': [self.repo_url],
                 'readme': repo_info['readme'],
                 'issues': repo_info['issues'],
                 'donate': repo_info['donate'],
@@ -118,6 +118,6 @@ class BitBucketRepositoryProvider(BaseRepositoryProvider):
             yield (name, details)
 
         except (DownloaderException, ClientException, ProviderException) as e:
-            self.failed_sources[self.repo] = e
+            self.failed_sources[self.repo_url] = e
             self.cache['get_packages'] = {}
             raise StopIteration()

--- a/package_control/providers/bitbucket_repository_provider.py
+++ b/package_control/providers/bitbucket_repository_provider.py
@@ -1,13 +1,13 @@
 import re
 
 from ..clients.bitbucket_client import BitBucketClient
-from ..downloaders.downloader_exception import DownloaderException
 from ..clients.client_exception import ClientException
+from ..downloaders.downloader_exception import DownloaderException
+from .base_repository_provider import BaseRepositoryProvider
 from .provider_exception import ProviderException
 
 
-class BitBucketRepositoryProvider():
-
+class BitBucketRepositoryProvider(BaseRepositoryProvider):
     """
     Allows using a public BitBucket repository as the source for a single package.
     For legacy purposes, this can also be treated as the source for a Package
@@ -31,57 +31,11 @@ class BitBucketRepositoryProvider():
           `query_string_params`
     """
 
-    def __init__(self, repo, settings):
-        self.cache = {}
-        self.repo = repo
-        self.settings = settings
-        self.failed_sources = {}
-
     @classmethod
     def match_url(cls, repo):
         """Indicates if this provider can handle the provided repo"""
 
         return re.search('^https?://bitbucket.org/([^/]+/[^/]+)/?$', repo) is not None
-
-    def prefetch(self):
-        """
-        Go out and perform HTTP operations, caching the result
-
-        :raises:
-            DownloaderException: when there is an issue download package info
-            ClientException: when there is an issue parsing package info
-        """
-
-        [name for name, info in self.get_packages()]
-
-    def get_failed_sources(self):
-        """
-        List of any URLs that could not be accessed while accessing this repository
-
-        :return:
-            A generator of ("https://bitbucket.org/user/repo", Exception()) tuples
-        """
-
-        return self.failed_sources.items()
-
-    def get_broken_packages(self):
-        """
-        For API-compatibility with RepositoryProvider
-        """
-
-        return {}.items()
-
-    def get_broken_dependencies(self):
-        """
-        For API-compatibility with RepositoryProvider
-        """
-
-        return {}.items()
-
-    def get_dependencies(self, ):
-        "For API-compatibility with RepositoryProvider"
-
-        return {}.items()
 
     def get_packages(self, invalid_sources=None):
         """
@@ -167,18 +121,3 @@ class BitBucketRepositoryProvider():
             self.failed_sources[self.repo] = e
             self.cache['get_packages'] = {}
             raise StopIteration()
-
-    def get_sources(self):
-        """
-        Return a list of current URLs that are directly referenced by the repo
-
-        :return:
-            A list of URLs
-        """
-
-        return [self.repo]
-
-    def get_renamed_packages(self):
-        """For API-compatibility with RepositoryProvider"""
-
-        return {}

--- a/package_control/providers/channel_provider.py
+++ b/package_control/providers/channel_provider.py
@@ -297,10 +297,17 @@ class ChannelProvider:
                 del copy['platforms']
             else:
                 last_modified = None
+
                 for release in copy.get('releases', []):
                     date = release.get('date')
                     if not last_modified or (date and date > last_modified):
                         last_modified = date
+
+                    if self.schema_version.major < 4:
+                        if 'dependencies' in release:
+                            release['libraries'] = release['dependencies']
+                            del release['dependencies']
+
                 copy['last_modified'] = last_modified
 
             defaults = {

--- a/package_control/providers/channel_provider.py
+++ b/package_control/providers/channel_provider.py
@@ -335,7 +335,7 @@ class ChannelProvider:
         :return:
             A dict in the format:
             {
-                'Dependency Name': {
+                'Library Name': {
                     'name': name,
                     'load_order': two digit string,
                     'description': description,

--- a/package_control/providers/github_user_provider.py
+++ b/package_control/providers/github_user_provider.py
@@ -1,13 +1,13 @@
 import re
 
+from ..clients.client_exception import ClientException
 from ..clients.github_client import GitHubClient
 from ..downloaders.downloader_exception import DownloaderException
-from ..clients.client_exception import ClientException
+from .base_repository_provider import BaseRepositoryProvider
 from .provider_exception import ProviderException
 
 
-class GitHubUserProvider():
-
+class GitHubUserProvider(BaseRepositoryProvider):
     """
     Allows using a GitHub user/organization as the source for multiple packages,
     or in Package Control terminology, a "repository".
@@ -30,57 +30,11 @@ class GitHubUserProvider():
           `query_string_params`
     """
 
-    def __init__(self, repo, settings):
-        self.cache = {}
-        self.repo = repo
-        self.settings = settings
-        self.failed_sources = {}
-
     @classmethod
     def match_url(cls, repo):
         """Indicates if this provider can handle the provided repo"""
 
         return re.search('^https?://github.com/[^/]+/?$', repo) is not None
-
-    def prefetch(self):
-        """
-        Go out and perform HTTP operations, caching the result
-        """
-
-        [name for name, info in self.get_packages()]
-
-    def get_failed_sources(self):
-        """
-        List of any URLs that could not be accessed while accessing this repository
-
-        :raises:
-            DownloaderException: when there is an issue download package info
-            ClientException: when there is an issue parsing package info
-
-        :return:
-            A generator of ("https://github.com/user/repo", Exception()) tuples
-        """
-
-        return self.failed_sources.items()
-
-    def get_broken_packages(self):
-        """
-        For API-compatibility with RepositoryProvider
-        """
-
-        return {}.items()
-
-    def get_broken_dependencies(self):
-        """
-        For API-compatibility with RepositoryProvider
-        """
-
-        return {}.items()
-
-    def get_dependencies(self, ):
-        "For API-compatibility with RepositoryProvider"
-
-        return {}.items()
 
     def get_packages(self, invalid_sources=None):
         """
@@ -175,18 +129,3 @@ class GitHubUserProvider():
                 self.failed_sources[repo_url] = e
 
         self.cache['get_packages'] = output
-
-    def get_sources(self):
-        """
-        Return a list of current URLs that are directly referenced by the repo
-
-        :return:
-            A list of URLs
-        """
-
-        return [self.repo]
-
-    def get_renamed_packages(self):
-        """For API-compatibility with RepositoryProvider"""
-
-        return {}

--- a/package_control/providers/github_user_provider.py
+++ b/package_control/providers/github_user_provider.py
@@ -12,7 +12,7 @@ class GitHubUserProvider(BaseRepositoryProvider):
     Allows using a GitHub user/organization as the source for multiple packages,
     or in Package Control terminology, a "repository".
 
-    :param repo:
+    :param repo_url:
         The public web URL to the GitHub user/org. Should be in the format
         `https://github.com/user`.
 
@@ -31,10 +31,10 @@ class GitHubUserProvider(BaseRepositoryProvider):
     """
 
     @classmethod
-    def match_url(cls, repo):
-        """Indicates if this provider can handle the provided repo"""
+    def match_url(cls, repo_url):
+        """Indicates if this provider can handle the provided repo_url"""
 
-        return re.search('^https?://github.com/[^/]+/?$', repo) is not None
+        return re.search('^https?://github.com/[^/]+/?$', repo_url) is not None
 
     def get_packages(self, invalid_sources=None):
         """
@@ -83,15 +83,15 @@ class GitHubUserProvider(BaseRepositoryProvider):
                 yield (key, value)
             return
 
-        if invalid_sources is not None and self.repo in invalid_sources:
+        if invalid_sources is not None and self.repo_url in invalid_sources:
             raise StopIteration()
 
         client = GitHubClient(self.settings)
 
         try:
-            user_repos = client.user_info(self.repo)
+            user_repos = client.user_info(self.repo_url)
         except (DownloaderException, ClientException) as e:
-            self.failed_sources[self.repo] = e
+            self.failed_sources[self.repo_url] = e
             self.cache['get_packages'] = {}
             raise
 
@@ -116,7 +116,7 @@ class GitHubUserProvider(BaseRepositoryProvider):
                     'releases': releases,
                     'previous_names': [],
                     'labels': [],
-                    'sources': [self.repo],
+                    'sources': [self.repo_url],
                     'readme': repo_info['readme'],
                     'issues': repo_info['issues'],
                     'donate': repo_info['donate'],

--- a/package_control/providers/gitlab_repository_provider.py
+++ b/package_control/providers/gitlab_repository_provider.py
@@ -13,7 +13,7 @@ class GitLabRepositoryProvider(BaseRepositoryProvider):
     For legacy purposes, this can also be treated as the source for a Package
     Control "repository".
 
-    :param repo:
+    :param repo_url:
         The public web URL to the GitLab repository. Should be in the format
         `https://gitlab.com/user/package` for the master branch, or
         `https://gitlab.com/user/package/-/tree/{branch_name}` for any other
@@ -33,16 +33,16 @@ class GitLabRepositoryProvider(BaseRepositoryProvider):
           `query_string_params`
     """
 
-    def __init__(self, repo, settings):
+    def __init__(self, repo_url, settings):
         # Clean off the trailing .git to be more forgiving
-        super().__init__(re.sub(r'\.git$', '', repo), settings)
+        super().__init__(re.sub(r'\.git$', '', repo_url), settings)
 
     @classmethod
-    def match_url(cls, repo):
-        """Indicates if this provider can handle the provided repo"""
+    def match_url(cls, repo_url):
+        """Indicates if this provider can handle the provided repo_url"""
 
-        master = re.search('^https?://gitlab.com/[^/]+/[^/]+/?$', repo)
-        branch = re.search('^https?://gitlab.com/[^/]+/[^/]+/-/tree/[^/]+/?$', repo)
+        master = re.search('^https?://gitlab.com/[^/]+/[^/]+/?$', repo_url)
+        branch = re.search('^https?://gitlab.com/[^/]+/[^/]+/-/tree/[^/]+/?$', repo_url)
         return master is not None or branch is not None
 
     def get_packages(self, invalid_sources=None):
@@ -92,16 +92,16 @@ class GitLabRepositoryProvider(BaseRepositoryProvider):
                 yield (key, value)
             return
 
-        if invalid_sources is not None and self.repo in invalid_sources:
+        if invalid_sources is not None and self.repo_url in invalid_sources:
             raise StopIteration()
 
         client = GitLabClient(self.settings)
 
         try:
-            repo_info = client.repo_info(self.repo)
+            repo_info = client.repo_info(self.repo_url)
 
             releases = []
-            for download in client.download_info(self.repo):
+            for download in client.download_info(self.repo_url):
                 download['sublime_text'] = '*'
                 download['platforms'] = ['*']
                 releases.append(download)
@@ -116,7 +116,7 @@ class GitLabRepositoryProvider(BaseRepositoryProvider):
                 'releases': releases,
                 'previous_names': [],
                 'labels': [],
-                'sources': [self.repo],
+                'sources': [self.repo_url],
                 'readme': repo_info['readme'],
                 'issues': repo_info['issues'],
                 'donate': repo_info['donate'],
@@ -126,6 +126,6 @@ class GitLabRepositoryProvider(BaseRepositoryProvider):
             yield (name, details)
 
         except (DownloaderException, ClientException, ProviderException) as e:
-            self.failed_sources[self.repo] = e
+            self.failed_sources[self.repo_url] = e
             self.cache['get_packages'] = {}
             raise StopIteration()

--- a/package_control/providers/gitlab_repository_provider.py
+++ b/package_control/providers/gitlab_repository_provider.py
@@ -1,12 +1,13 @@
 import re
 
+from ..clients.client_exception import ClientException
 from ..clients.gitlab_client import GitLabClient
 from ..downloaders.downloader_exception import DownloaderException
-from ..clients.client_exception import ClientException
+from .base_repository_provider import BaseRepositoryProvider
 from .provider_exception import ProviderException
 
 
-class GitLabRepositoryProvider():
+class GitLabRepositoryProvider(BaseRepositoryProvider):
     """
     Allows using a public GitLab repository as the source for a single package.
     For legacy purposes, this can also be treated as the source for a Package
@@ -33,11 +34,8 @@ class GitLabRepositoryProvider():
     """
 
     def __init__(self, repo, settings):
-        self.cache = {}
         # Clean off the trailing .git to be more forgiving
-        self.repo = re.sub(r'\.git$', '', repo)
-        self.settings = settings
-        self.failed_sources = {}
+        super().__init__(re.sub(r'\.git$', '', repo), settings)
 
     @classmethod
     def match_url(cls, repo):
@@ -46,46 +44,6 @@ class GitLabRepositoryProvider():
         master = re.search('^https?://gitlab.com/[^/]+/[^/]+/?$', repo)
         branch = re.search('^https?://gitlab.com/[^/]+/[^/]+/-/tree/[^/]+/?$', repo)
         return master is not None or branch is not None
-
-    def prefetch(self):
-        """
-        Go out and perform HTTP operations, caching the result
-
-        :raises:
-            DownloaderException: when there is an issue download package info
-            ClientException: when there is an issue parsing package info
-        """
-
-        [name for name, info in self.get_packages()]
-
-    def get_failed_sources(self):
-        """
-        List of any URLs that could not be accessed while accessing this repository
-
-        :return:
-            A generator of ("https://gitlab.com/user/repo", Exception()) tuples
-        """
-
-        return self.failed_sources.items()
-
-    def get_broken_packages(self):
-        """
-        For API-compatibility with RepositoryProvider
-        """
-
-        return {}.items()
-
-    def get_broken_dependencies(self):
-        """
-        For API-compatibility with RepositoryProvider
-        """
-
-        return {}.items()
-
-    def get_dependencies(self, ):
-        """For API-compatibility with RepositoryProvider"""
-
-        return {}.items()
 
     def get_packages(self, invalid_sources=None):
         """
@@ -171,18 +129,3 @@ class GitLabRepositoryProvider():
             self.failed_sources[self.repo] = e
             self.cache['get_packages'] = {}
             raise StopIteration()
-
-    def get_sources(self):
-        """
-        Return a list of current URLs that are directly referenced by the repo
-
-        :return:
-            A list of URLs
-        """
-
-        return [self.repo]
-
-    def get_renamed_packages(self):
-        """For API-compatibility with RepositoryProvider"""
-
-        return {}

--- a/package_control/providers/gitlab_user_provider.py
+++ b/package_control/providers/gitlab_user_provider.py
@@ -3,10 +3,11 @@ import re
 from ..clients.client_exception import ClientException
 from ..clients.gitlab_client import GitLabClient
 from ..downloaders.downloader_exception import DownloaderException
+from .base_repository_provider import BaseRepositoryProvider
 from .provider_exception import ProviderException
 
 
-class GitLabUserProvider:
+class GitLabUserProvider(BaseRepositoryProvider):
     """
     Allows using a GitLab user/organization as the source for multiple packages,
     or in Package Control terminology, a 'repository'.
@@ -29,12 +30,6 @@ class GitLabUserProvider:
           `query_string_params`
     """
 
-    def __init__(self, repo, settings):
-        self.cache = {}
-        self.repo = repo
-        self.settings = settings
-        self.failed_sources = {}
-
     @classmethod
     def match_url(cls, repo):
         """
@@ -42,46 +37,6 @@ class GitLabUserProvider:
         """
 
         return re.search('^https?://gitlab.com/[^/]+/?$', repo) is not None
-
-    def prefetch(self):
-        """
-        Go out and perform HTTP operations, caching the result
-        """
-
-        [name for name, info in self.get_packages()]
-
-    def get_failed_sources(self):
-        """
-        List of any URLs that could not be accessed while accessing this repository
-
-        :raises:
-            DownloaderException: when there is an issue download package info
-            ClientException: when there is an issue parsing package info
-
-        :return:
-            A generator of ('https://gitlab.com/user/repo', Exception()) tuples
-        """
-
-        return self.failed_sources.items()
-
-    def get_broken_packages(self):
-        """
-        For API-compatibility with RepositoryProvider
-        """
-
-        return {}.items()
-
-    def get_broken_dependencies(self):
-        """
-        For API-compatibility with RepositoryProvider
-        """
-
-        return {}.items()
-
-    def get_dependencies(self, ):
-        '''For API-compatibility with RepositoryProvider'''
-
-        return {}.items()
 
     def get_packages(self, invalid_sources=None):
         """
@@ -178,18 +133,3 @@ class GitLabUserProvider:
                 self.failed_sources[repo_url] = e
 
         self.cache['get_packages'] = output
-
-    def get_sources(self):
-        """
-        Return a list of current URLs that are directly referenced by the repo
-
-        :return:
-            A list of URLs
-        """
-
-        return [self.repo]
-
-    def get_renamed_packages(self):
-        """For API-compatibility with RepositoryProvider"""
-
-        return {}

--- a/package_control/providers/gitlab_user_provider.py
+++ b/package_control/providers/gitlab_user_provider.py
@@ -12,7 +12,7 @@ class GitLabUserProvider(BaseRepositoryProvider):
     Allows using a GitLab user/organization as the source for multiple packages,
     or in Package Control terminology, a 'repository'.
 
-    :param repo:
+    :param repo_url:
         The public web URL to the GitHub user/org. Should be in the format
         `https://gitlab.com/user`.
 
@@ -31,12 +31,12 @@ class GitLabUserProvider(BaseRepositoryProvider):
     """
 
     @classmethod
-    def match_url(cls, repo):
+    def match_url(cls, repo_url):
         """
-        Indicates if this provider can handle the provided repo
+        Indicates if this provider can handle the provided repo_url
         """
 
-        return re.search('^https?://gitlab.com/[^/]+/?$', repo) is not None
+        return re.search('^https?://gitlab.com/[^/]+/?$', repo_url) is not None
 
     def get_packages(self, invalid_sources=None):
         """
@@ -85,15 +85,15 @@ class GitLabUserProvider(BaseRepositoryProvider):
                 yield (key, value)
             return
 
-        if invalid_sources is not None and self.repo in invalid_sources:
+        if invalid_sources is not None and self.repo_url in invalid_sources:
             raise StopIteration()
 
         client = GitLabClient(self.settings)
 
         try:
-            user_repos = client.user_info(self.repo)
+            user_repos = client.user_info(self.repo_url)
         except (DownloaderException, ClientException) as e:
-            self.failed_sources[self.repo] = e
+            self.failed_sources[self.repo_url] = e
             self.cache['get_packages'] = {}
             raise
 
@@ -119,7 +119,7 @@ class GitLabUserProvider(BaseRepositoryProvider):
                     'releases': releases,
                     'previous_names': [],
                     'labels': [],
-                    'sources': [self.repo],
+                    'sources': [self.repo_url],
                     'readme': repo_info['readme'],
                     'issues': repo_info['issues'],
                     'donate': repo_info['donate'],

--- a/package_control/providers/repository_provider.py
+++ b/package_control/providers/repository_provider.py
@@ -24,7 +24,7 @@ class InvalidRepoFileException(ProviderException):
     def __init__(self, repo, reason_message):
         super().__init__(
             'Repository %s does not appear to be a valid repository file because'
-            ' %s' % (repo.repo, reason_message))
+            ' %s' % (repo.repo_url, reason_message))
 
 
 class RepositoryProvider(BaseRepositoryProvider):

--- a/package_control/providers/repository_provider.py
+++ b/package_control/providers/repository_provider.py
@@ -481,7 +481,7 @@ class RepositoryProvider(BaseRepositoryProvider):
                             'url': url,
                             'date': date,
                             'version': version,
-                            'dependencies': [library name, ...]
+                            'libraries': [library name, ...]
                         }, ...
                     ]
                     'previous_names': [old_name, ...],
@@ -630,7 +630,7 @@ class RepositoryProvider(BaseRepositoryProvider):
                     download_info = {}
 
                     # Make sure that explicit fields are copied over
-                    for field in ['platforms', 'sublime_text', 'version', 'url', 'date', 'dependencies']:
+                    for field in ['platforms', 'sublime_text', 'version', 'url', 'date', 'libraries']:
                         if field in release:
                             value = release[field]
                             if field == 'url':
@@ -638,6 +638,9 @@ class RepositoryProvider(BaseRepositoryProvider):
                             if field == 'platforms' and not isinstance(release['platforms'], list):
                                 value = [value]
                             download_info[field] = value
+
+                    if self.schema_version.major < 4 and 'dependencies' in release:
+                        download_info['libraries'] = release['dependencies']
 
                     if 'platforms' not in download_info:
                         download_info['platforms'] = ['*']

--- a/package_control/providers/repository_provider.py
+++ b/package_control/providers/repository_provider.py
@@ -680,7 +680,7 @@ class RepositoryProvider(BaseRepositoryProvider):
                         elif download_info:
                             info['releases'].append(download_info)
 
-                    elif self.schema_version.major == 3:
+                    elif self.schema_version.major >= 3:
                         tags = release.get('tags')
                         branch = release.get('branch')
 

--- a/package_control/providers/repository_provider.py
+++ b/package_control/providers/repository_provider.py
@@ -212,7 +212,7 @@ class RepositoryProvider(BaseRepositoryProvider):
         :return:
             A generator of
             (
-                'Dependency Name',
+                'Library Name',
                 {
                     'name': name,
                     'load_order': two digit string,
@@ -247,14 +247,14 @@ class RepositoryProvider(BaseRepositoryProvider):
             return
 
         if self.schema_version.major >= 4:
-            allowed_dependency_keys = {
+            allowed_library_keys = {
                 'name', 'description', 'author', 'issues', 'releases'
             }
             allowed_release_keys = {  # todo: remove 'branch'
                 'base', 'version', 'sublime_text', 'platforms', 'python_versions', 'branch', 'tags', 'url', 'sha256'
             }
         else:
-            allowed_dependency_keys = {
+            allowed_library_keys = {
                 'name', 'description', 'author', 'issues', 'load_order', 'releases'
             }
             allowed_release_keys = {
@@ -289,7 +289,7 @@ class RepositoryProvider(BaseRepositoryProvider):
                 continue
 
             try:
-                unknown_keys = set(library) - allowed_dependency_keys
+                unknown_keys = set(library) - allowed_library_keys
                 if unknown_keys:
                     raise ProviderException(text.format(
                         '''

--- a/package_control/providers/schema_compat.py
+++ b/package_control/providers/schema_compat.py
@@ -49,7 +49,7 @@ def platforms_to_releases(info, debug):
 
 
 class SchemaVersion(SemVer):
-    supported_versions = ('1.0', '1.1', '1.2', '2.0', '3.0.0')
+    supported_versions = ('1.0', '1.1', '1.2', '2.0', '3.0.0', '3.1.0')
 
     @classmethod
     def _parse(cls, ver):

--- a/package_control/providers/schema_compat.py
+++ b/package_control/providers/schema_compat.py
@@ -1,4 +1,5 @@
 from ..download_manager import update_url
+from ..semver import SemVer
 
 
 def platforms_to_releases(info, debug):
@@ -45,3 +46,39 @@ def platforms_to_releases(info, debug):
         output.append(release)
 
     return output
+
+
+class SchemaVersion(SemVer):
+    supported_versions = ('1.0', '1.1', '1.2', '2.0', '3.0.0')
+
+    @classmethod
+    def _parse(cls, ver):
+        """
+        Custom version string parsing to maintain backward compatibility.
+
+        SemVer needs all of major, minor and patch parts being present in `ver`.
+
+        :param ver:
+            An integer, float or string containing a version string.
+
+        :returns:
+            List of (major, minor, patch)
+        """
+        try:
+            if isinstance(ver, int):
+                ver = float(ver)
+            if isinstance(ver, float):
+                ver = str(ver)
+        except ValueError:
+            raise ValueError('the "schema_version" is not a valid number.')
+
+        if ver not in cls.supported_versions:
+            raise ValueError(
+                'the "schema_version" is not recognized. Must be one of: %s or %s.'
+                % (', '.join(cls.supported_versions[:-1]), cls.supported_versions[-1])
+            )
+
+        if ver.count('.') == 1:
+            ver += '.0'
+
+        return SemVer._parse(ver)

--- a/package_control/providers/schema_compat.py
+++ b/package_control/providers/schema_compat.py
@@ -49,7 +49,7 @@ def platforms_to_releases(info, debug):
 
 
 class SchemaVersion(SemVer):
-    supported_versions = ('1.0', '1.1', '1.2', '2.0', '3.0.0', '3.1.0')
+    supported_versions = ('1.0', '1.1', '1.2', '2.0', '3.0.0', '4.0.0')
 
     @classmethod
     def _parse(cls, ver):

--- a/package_control/tests/providers.py
+++ b/package_control/tests/providers.py
@@ -2114,6 +2114,8 @@ class ChannelProviderTests(unittest.TestCase):
                 "https://raw.githubusercontent.com/wbond/package_control-json"
                 "/master/repository-3.0.0-github_releases.json",
                 "https://raw.githubusercontent.com/wbond/package_control-json"
+                "/master/repository-3.0.0-gitlab_releases.json",
+                "https://raw.githubusercontent.com/wbond/package_control-json"
                 "/master/repository-3.0.0-bitbucket_releases.json"
             ],
             provider.get_sources()

--- a/package_control/tests/providers.py
+++ b/package_control/tests/providers.py
@@ -1,13 +1,13 @@
 import unittest
 
-from ..providers.repository_provider import RepositoryProvider
+from ..http_cache import HttpCache
+from ..providers.bitbucket_repository_provider import BitBucketRepositoryProvider
 from ..providers.channel_provider import ChannelProvider
 from ..providers.github_repository_provider import GitHubRepositoryProvider
 from ..providers.github_user_provider import GitHubUserProvider
 from ..providers.gitlab_repository_provider import GitLabRepositoryProvider
 from ..providers.gitlab_user_provider import GitLabUserProvider
-from ..providers.bitbucket_repository_provider import BitBucketRepositoryProvider
-from ..http_cache import HttpCache
+from ..providers.repository_provider import RepositoryProvider
 
 from . import LAST_COMMIT_TIMESTAMP, LAST_COMMIT_VERSION, CLIENT_ID, CLIENT_SECRET, USER_AGENT
 
@@ -106,21 +106,21 @@ class GitHubRepositoryProviderTests(unittest.TestCase):
             'https://github.com/packagecontrol-test/package_control-tester',
             self.github_settings()
         )
-        self.assertEqual(list(), list(provider.get_broken_packages()))
+        self.assertEqual([], list(provider.get_broken_packages()))
 
-    def test_get_dependencies(self):
+    def test_get_libraries(self):
         provider = GitHubRepositoryProvider(
             'https://github.com/packagecontrol-test/package_control-tester',
             self.github_settings()
         )
-        self.assertEqual(list(), list(provider.get_dependencies()))
+        self.assertEqual([], list(provider.get_libraries()))
 
-    def test_get_broken_dependencies(self):
+    def test_get_broken_libraries(self):
         provider = GitHubRepositoryProvider(
             'https://github.com/packagecontrol-test/package_control-tester',
             self.github_settings()
         )
-        self.assertEqual(list(), list(provider.get_broken_dependencies()))
+        self.assertEqual([], list(provider.get_broken_libraries()))
 
 
 class GitHubUserProviderTests(unittest.TestCase):
@@ -202,15 +202,15 @@ class GitHubUserProviderTests(unittest.TestCase):
 
     def test_get_broken_packages(self):
         provider = GitHubUserProvider('https://github.com/packagecontrol-test', self.github_settings())
-        self.assertEqual(list(), list(provider.get_broken_packages()))
+        self.assertEqual([], list(provider.get_broken_packages()))
 
-    def test_get_dependencies(self):
+    def test_get_libraries(self):
         provider = GitHubUserProvider('https://github.com/packagecontrol-test', self.github_settings())
-        self.assertEqual(list(), list(provider.get_dependencies()))
+        self.assertEqual([], list(provider.get_libraries()))
 
-    def test_get_broken_dependencies(self):
+    def test_get_broken_libraries(self):
         provider = GitHubUserProvider('https://github.com/packagecontrol-test', self.github_settings())
-        self.assertEqual(list(), list(provider.get_broken_dependencies()))
+        self.assertEqual([], list(provider.get_broken_libraries()))
 
 
 class GitLabRepositoryProviderTests(unittest.TestCase):
@@ -302,21 +302,21 @@ class GitLabRepositoryProviderTests(unittest.TestCase):
             'https://gitlab.com/packagecontrol-test/package_control-tester',
             self.gitlab_settings()
         )
-        self.assertEqual(list(), list(provider.get_broken_packages()))
+        self.assertEqual([], list(provider.get_broken_packages()))
 
-    def test_get_dependencies(self):
+    def test_get_libraries(self):
         provider = GitLabRepositoryProvider(
             'https://gitlab.com/packagecontrol-test/package_control-tester',
             self.gitlab_settings()
         )
-        self.assertEqual(list(), list(provider.get_dependencies()))
+        self.assertEqual([], list(provider.get_libraries()))
 
-    def test_get_broken_dependencies(self):
+    def test_get_broken_libraries(self):
         provider = GitLabRepositoryProvider(
             'https://gitlab.com/packagecontrol-test/package_control-tester',
             self.gitlab_settings()
         )
-        self.assertEqual(list(), list(provider.get_broken_dependencies()))
+        self.assertEqual([], list(provider.get_broken_libraries()))
 
 
 class GitLabUserProviderTests(unittest.TestCase):
@@ -390,15 +390,15 @@ class GitLabUserProviderTests(unittest.TestCase):
 
     def test_get_broken_packages(self):
         provider = GitLabUserProvider('https://gitlab.com/packagecontrol-test', self.gitlab_settings())
-        self.assertEqual(list(), list(provider.get_broken_packages()))
+        self.assertEqual([], list(provider.get_broken_packages()))
 
-    def test_get_dependencies(self):
+    def test_get_libraries(self):
         provider = GitLabUserProvider('https://gitlab.com/packagecontrol-test', self.gitlab_settings())
-        self.assertEqual(list(), list(provider.get_dependencies()))
+        self.assertEqual([], list(provider.get_libraries()))
 
-    def test_get_broken_dependencies(self):
+    def test_get_broken_libraries(self):
         provider = GitLabUserProvider('https://gitlab.com/packagecontrol-test', self.gitlab_settings())
-        self.assertEqual(list(), list(provider.get_broken_dependencies()))
+        self.assertEqual([], list(provider.get_broken_libraries()))
 
 
 class BitBucketRepositoryProviderTests(unittest.TestCase):
@@ -485,21 +485,21 @@ class BitBucketRepositoryProviderTests(unittest.TestCase):
             'https://bitbucket.org/wbond/package_control-tester',
             self.bitbucket_settings()
         )
-        self.assertEqual(list(), list(provider.get_broken_packages()))
+        self.assertEqual([], list(provider.get_broken_packages()))
 
-    def test_get_dependencies(self):
+    def test_get_libraries(self):
         provider = BitBucketRepositoryProvider(
             'https://bitbucket.org/wbond/package_control-tester',
             self.bitbucket_settings()
         )
-        self.assertEqual(list(), list(provider.get_dependencies()))
+        self.assertEqual([], list(provider.get_libraries()))
 
-    def test_get_broken_dependencies(self):
+    def test_get_broken_libraries(self):
         provider = BitBucketRepositoryProvider(
             'https://bitbucket.org/wbond/package_control-tester',
             self.bitbucket_settings()
         )
-        self.assertEqual(list(), list(provider.get_broken_dependencies()))
+        self.assertEqual([], list(provider.get_broken_libraries()))
 
 
 class RepositoryProviderTests(unittest.TestCase):
@@ -575,13 +575,12 @@ class RepositoryProviderTests(unittest.TestCase):
             packages
         )
 
-    def test_get_dependencies_10(self):
+    def test_get_libraries_10(self):
         provider = RepositoryProvider(
             'https://raw.githubusercontent.com/wbond/package_control-json/master/repository-1.0.json',
             self.settings()
         )
-        dependencies = [dependency for dependency in provider.get_dependencies()]
-        self.assertEqual([], dependencies)
+        self.assertEqual([], list(provider.get_libraries()))
 
     def test_get_packages_12(self):
         provider = RepositoryProvider(
@@ -639,13 +638,12 @@ class RepositoryProviderTests(unittest.TestCase):
             packages
         )
 
-    def test_get_dependencies_12(self):
+    def test_get_libraries_12(self):
         provider = RepositoryProvider(
             'https://raw.githubusercontent.com/wbond/package_control-json/master/repository-1.2.json',
             self.settings()
         )
-        dependencies = [dependency for dependency in provider.get_dependencies()]
-        self.assertEqual([], dependencies)
+        self.assertEqual([], list(provider.get_libraries()))
 
     def test_get_packages_20_explicit(self):
         provider = RepositoryProvider(
@@ -712,13 +710,12 @@ class RepositoryProviderTests(unittest.TestCase):
             packages
         )
 
-    def test_get_dependencies_20(self):
+    def test_get_libraries_20(self):
         provider = RepositoryProvider(
             'https://raw.githubusercontent.com/wbond/package_control-json/master/repository-2.0-explicit.json',
             self.settings()
         )
-        dependencies = [dependency for dependency in provider.get_dependencies()]
-        self.assertEqual([], dependencies)
+        self.assertEqual([], list(provider.get_libraries()))
 
     def test_get_packages_20_github(self):
         provider = RepositoryProvider(
@@ -916,19 +913,17 @@ class RepositoryProviderTests(unittest.TestCase):
             packages
         )
 
-    def test_get_dependencies_300_explicit(self):
+    def test_get_libraries_300_explicit(self):
         provider = RepositoryProvider(
             'https://raw.githubusercontent.com/wbond/package_control-json/master/repository-3.0.0-explicit.json',
             self.settings()
         )
-        dependencies = [dependency for dependency in provider.get_dependencies()]
         self.assertEqual(
             [
                 (
                     'bz2',
                     {
                         "name": "bz2",
-                        "load_order": "02",
                         "author": "wbond",
                         "description": "Python bz2 module",
                         "issues": "https://github.com/wbond/package_control/issues",
@@ -951,7 +946,6 @@ class RepositoryProviderTests(unittest.TestCase):
                     'ssl-linux',
                     {
                         "name": "ssl-linux",
-                        "load_order": "01",
                         "description": "Python _ssl module for Linux",
                         "author": "wbond",
                         "issues": "https://github.com/wbond/package_control/issues",
@@ -975,7 +969,6 @@ class RepositoryProviderTests(unittest.TestCase):
                     'ssl-windows',
                     {
                         "name": "ssl-windows",
-                        "load_order": "01",
                         "description": "Python _ssl module for Sublime Text 2 on Windows",
                         "author": "wbond",
                         "issues": "https://github.com/wbond/package_control/issues",
@@ -996,7 +989,7 @@ class RepositoryProviderTests(unittest.TestCase):
                     }
                 )
             ],
-            dependencies
+            list(provider.get_libraries())
         )
 
     def test_get_packages_300_github(self):
@@ -1462,25 +1455,23 @@ class RepositoryProviderTests(unittest.TestCase):
             packages
         )
 
-    def test_get_dependencies_310_explicit(self):
+    def test_get_libraries_400_explicit(self):
         provider = RepositoryProvider(
-            'https://raw.githubusercontent.com/wbond/package_control-json/master/repository-3.1.0-explicit.json',
+            'https://raw.githubusercontent.com/wbond/package_control-json/master/repository-4.0.0-explicit.json',
             self.settings()
         )
-        dependencies = [dependency for dependency in provider.get_dependencies()]
         self.assertEqual(
             [
                 (
                     'bz2',
                     {
                         "name": "bz2",
-                        "load_order": "02",
                         "author": "wbond",
                         "description": "Python bz2 module",
                         "issues": "https://github.com/wbond/package_control/issues",
                         "sources": [
                             'https://raw.githubusercontent.com/wbond/package_control-json'
-                            '/master/repository-3.1.0-explicit.json'
+                            '/master/repository-4.0.0-explicit.json'
                         ],
                         "releases": [
                             {
@@ -1497,13 +1488,12 @@ class RepositoryProviderTests(unittest.TestCase):
                     'ssl-linux',
                     {
                         "name": "ssl-linux",
-                        "load_order": "01",
                         "description": "Python _ssl module for Linux",
                         "author": "wbond",
                         "issues": "https://github.com/wbond/package_control/issues",
                         "sources": [
                             'https://raw.githubusercontent.com/wbond/package_control-json'
-                            '/master/repository-3.1.0-explicit.json'
+                            '/master/repository-4.0.0-explicit.json'
                         ],
                         "releases": [
                             {
@@ -1519,20 +1509,20 @@ class RepositoryProviderTests(unittest.TestCase):
                 ),
                 # Note: 'ssl-windows' is expected to not be present because of missing python_versions!
             ],
-            dependencies
+            list(provider.get_libraries())
         )
 
-    def test_get_packages_310_explicit(self):
+    def test_get_packages_400_explicit(self):
         provider = RepositoryProvider(
-            'https://raw.githubusercontent.com/wbond/package_control-json/master/repository-3.1.0-explicit.json',
+            'https://raw.githubusercontent.com/wbond/package_control-json/master/repository-4.0.0-explicit.json',
             self.settings()
         )
         packages = [package for package in provider.get_packages()]
         self.assertEqual(
             [(
-                'package_control-tester-3.1.0',
+                'package_control-tester-4.0.0',
                 {
-                    "name": "package_control-tester-3.1.0",
+                    "name": "package_control-tester-4.0.0",
                     "author": ["packagecontrol", "wbond"],
                     "description": "A test of Package Control upgrade messages with "
                                    "explicit versions, but date-based releases.",
@@ -1545,7 +1535,7 @@ class RepositoryProviderTests(unittest.TestCase):
                     "labels": [],
                     "sources": [
                         'https://raw.githubusercontent.com/wbond/package_control-json'
-                        '/master/repository-3.1.0-explicit.json'
+                        '/master/repository-4.0.0-explicit.json'
                     ],
                     "last_modified": "2014-11-12 15:52:35",
                     "releases": [
@@ -2551,7 +2541,7 @@ class ChannelProviderTests(unittest.TestCase):
             )
         )
 
-    def test_get_dependencies_300(self):
+    def test_get_libraries_300(self):
         self.maxDiff = None
         provider = ChannelProvider(
             'https://raw.githubusercontent.com/wbond/package_control-json/master/channel-3.0.0.json',
@@ -2607,7 +2597,7 @@ class ChannelProviderTests(unittest.TestCase):
                     ]
                 }
             },
-            provider.get_dependencies(
+            provider.get_libraries(
                 "https://raw.githubusercontent.com/wbond/package_control-json/master/repository-3.0.0-explicit.json"
             )
         )

--- a/package_control/tests/providers.py
+++ b/package_control/tests/providers.py
@@ -373,7 +373,7 @@ class GitLabUserProviderTests(unittest.TestCase):
                         'platforms': ['*'],
                         'url': 'https://gitlab.com/packagecontrol-test/'
                         'package_control-tester/-/archive/master/package_control-tester-master.zip'
-                        }],
+                    }],
                     'last_modified': '2020-07-15 10:50:38'
                 }
             )],
@@ -941,7 +941,8 @@ class RepositoryProviderTests(unittest.TestCase):
                                 "version": "1.0.0",
                                 "url": "https://packagecontrol.io/bz2.sublime-package",
                                 "sublime_text": "*",
-                                "platforms": ["*"]
+                                "platforms": ["*"],
+                                "python_versions": ["3.3"]
                             }
                         ]
                     }
@@ -964,6 +965,7 @@ class RepositoryProviderTests(unittest.TestCase):
                                 "url": "http://packagecontrol.io/ssl-linux.sublime-package",
                                 "sublime_text": "*",
                                 "platforms": ["linux"],
+                                "python_versions": ["3.3"],
                                 "sha256": "d12a2ca2843b3c06a834652e9827a29f88872bb31bd64230775f3dbe12e0ebd4"
                             }
                         ]
@@ -987,6 +989,7 @@ class RepositoryProviderTests(unittest.TestCase):
                                 "url": "http://packagecontrol.io/ssl-windows.sublime-package",
                                 "sublime_text": "<3000",
                                 "platforms": ["windows"],
+                                "python_versions": ["3.3"],
                                 "sha256": "efe25e3bdf2e8f791d86327978aabe093c9597a6ceb8c2fb5438c1d810e02bea"
                             }
                         ]
@@ -1456,6 +1459,132 @@ class RepositoryProviderTests(unittest.TestCase):
                     }
                 )
             ],
+            packages
+        )
+
+    def test_get_dependencies_310_explicit(self):
+        provider = RepositoryProvider(
+            'https://raw.githubusercontent.com/wbond/package_control-json/master/repository-3.1.0-explicit.json',
+            self.settings()
+        )
+        dependencies = [dependency for dependency in provider.get_dependencies()]
+        self.assertEqual(
+            [
+                (
+                    'bz2',
+                    {
+                        "name": "bz2",
+                        "load_order": "02",
+                        "author": "wbond",
+                        "description": "Python bz2 module",
+                        "issues": "https://github.com/wbond/package_control/issues",
+                        "sources": [
+                            'https://raw.githubusercontent.com/wbond/package_control-json'
+                            '/master/repository-3.1.0-explicit.json'
+                        ],
+                        "releases": [
+                            {
+                                "version": "1.0.0",
+                                "url": "https://packagecontrol.io/bz2.sublime-package",
+                                "sublime_text": "*",
+                                "platforms": ["*"],
+                                "python_versions": ["3.3"]
+                            }
+                        ]
+                    }
+                ),
+                (
+                    'ssl-linux',
+                    {
+                        "name": "ssl-linux",
+                        "load_order": "01",
+                        "description": "Python _ssl module for Linux",
+                        "author": "wbond",
+                        "issues": "https://github.com/wbond/package_control/issues",
+                        "sources": [
+                            'https://raw.githubusercontent.com/wbond/package_control-json'
+                            '/master/repository-3.1.0-explicit.json'
+                        ],
+                        "releases": [
+                            {
+                                "version": "1.0.0",
+                                "url": "http://packagecontrol.io/ssl-linux.sublime-package",
+                                "sublime_text": "*",
+                                "platforms": ["linux"],
+                                "python_versions": ["3.3", "3.8"],
+                                "sha256": "d12a2ca2843b3c06a834652e9827a29f88872bb31bd64230775f3dbe12e0ebd4"
+                            }
+                        ]
+                    }
+                ),
+                # Note: 'ssl-windows' is expected to not be present because of missing python_versions!
+            ],
+            dependencies
+        )
+
+    def test_get_packages_310_explicit(self):
+        provider = RepositoryProvider(
+            'https://raw.githubusercontent.com/wbond/package_control-json/master/repository-3.1.0-explicit.json',
+            self.settings()
+        )
+        packages = [package for package in provider.get_packages()]
+        self.assertEqual(
+            [(
+                'package_control-tester-3.1.0',
+                {
+                    "name": "package_control-tester-3.1.0",
+                    "author": ["packagecontrol", "wbond"],
+                    "description": "A test of Package Control upgrade messages with "
+                                   "explicit versions, but date-based releases.",
+                    "homepage": "https://github.com/packagecontrol-test/package_control-tester",
+                    "issues": None,
+                    "donate": "https://gratipay.com/wbond/",
+                    "buy": "https://example.com",
+                    "readme": None,
+                    "previous_names": [],
+                    "labels": [],
+                    "sources": [
+                        'https://raw.githubusercontent.com/wbond/package_control-json'
+                        '/master/repository-3.1.0-explicit.json'
+                    ],
+                    "last_modified": "2014-11-12 15:52:35",
+                    "releases": [
+                        {
+                            "version": "1.0.1",
+                            "date": "2014-11-12 15:52:35",
+                            "url": "https://codeload.github.com/packagecontrol-test"
+                                   "/package_control-tester/zip/1.0.1",
+                            "sublime_text": "*",
+                            "platforms": ["windows"],
+                            "dependencies": ["bz2"]
+                        },
+                        {
+                            "version": "1.0.1-beta",
+                            "date": "2014-11-12 15:14:23",
+                            "url": "https://codeload.github.com/packagecontrol-test"
+                                   "/package_control-tester/zip/1.0.1-beta",
+                            "sublime_text": "*",
+                            "platforms": ["windows"]
+                        },
+                        {
+                            "version": "1.0.0",
+                            "date": "2014-11-12 15:14:13",
+                            "url": "https://codeload.github.com/packagecontrol-test"
+                                   "/package_control-tester/zip/1.0.0",
+                            "sublime_text": "*",
+                            "platforms": ["*"]
+                        },
+                        {
+                            "version": "0.9.0",
+                            "date": "2014-11-12 02:02:22",
+                            "url": "https://codeload.github.com/packagecontrol-test"
+                                   "/package_control-tester/zip/0.9.0",
+                            "sublime_text": "<3000",
+                            "platforms": ["*"]
+                        }
+                    ]
+                }
+            )],
             packages
         )
 

--- a/package_control/tests/providers.py
+++ b/package_control/tests/providers.py
@@ -881,7 +881,7 @@ class RepositoryProviderTests(unittest.TestCase):
                                    "/package_control-tester/zip/1.0.1",
                             "sublime_text": "*",
                             "platforms": ["windows"],
-                            "dependencies": ["bz2"]
+                            "libraries": ["bz2"]
                         },
                         {
                             "version": "1.0.1-beta",
@@ -1546,7 +1546,7 @@ class RepositoryProviderTests(unittest.TestCase):
                                    "/package_control-tester/zip/1.0.1",
                             "sublime_text": "*",
                             "platforms": ["windows"],
-                            "dependencies": ["bz2"]
+                            "libraries": ["bz2"]
                         },
                         {
                             "version": "1.0.1-beta",
@@ -2148,7 +2148,7 @@ class ChannelProviderTests(unittest.TestCase):
                                    "/package_control-tester/zip/1.0.1",
                             "sublime_text": "*",
                             "platforms": ["windows"],
-                            "dependencies": ["bz2"]
+                            "libraries": ["bz2"]
                         },
                         {
                             "version": "1.0.1-beta",

--- a/package_control/wheel.py
+++ b/package_control/wheel.py
@@ -138,7 +138,7 @@ def generate_record(install_root, dist_info_dir, package_dirs, package_files):
 def extra_files():
     """
     :return:
-        A set of unicode strings containing "important" files in a dependency
+        A set of unicode strings containing "important" files in a library
         archive that should be relocated into the .dist-info directory to
         prevent depdencies overwriting each other in the lib folder
     """


### PR DESCRIPTION
Fixes #1516 

This PR bumps repository and channel scheme version to 4.0.0

1. Scheme versions are validated using `SemVer` class to be able to access major, minor, patch directly.
2. Json keys and related methods are renamed to use `libraries` instead of `dependencies`.
3. Library releases must provide `python_versions: ['3.3', ...]` as of scheme version `4.0.0`.
4. Libraries must not provide `load_order` as of scheme version `4.0.0`.
5. Included repositories' scheme version is validated and must match the scheme version of the including repository. That's required as several scheme changes are handled by checking the root repository's scheme version only.

Notes:

- [x] New integration tests for scheme 4.0.0 need https://github.com/wbond/package_control-json/pull/2
- [x] https://github.com/wbond/package_control/pull/1520 is needed to run integration tests successfully.
- [x] Not directly related but https://github.com/wbond/package_control/pull/1524 may need to be taken into account as well.