### PR TITLE
Update .gitignore and add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,5 +6,6 @@
 
 # development utilities
 /dev/ export-ignore
+tests/ export-ignore
 .travis.yml export-ignore
 tox.ini export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# git
+.github/ export-ignore
+.git export-ignore
+.gitignore export-ignore
+.gitattributes export-ignore
+
+# development utilities
+/dev/ export-ignore
+.travis.yml export-ignore
+tox.ini export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dev/.lint-deps/
 
 # linter cache
 .mypy_cache/
+.pytest_cache/
 .ropeproject/
 
 # python cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,16 @@
+# development dependencies
 dev/.lint-deps/
+
+# linter cache
+.mypy_cache/
+.ropeproject/
+
+# python cache
+__pycache__/
 *.pyc
+*.pyo
+
+# Sublime Text files
 *.sublime-project
-*.thTheme.cache
 *.sublime-workspace
-*.mypy_cache/
+*.thTheme.cache


### PR DESCRIPTION
Some packages or tools create cache files/folders within the project which just can be ignored by git.

Other files are crucial for the repository but don't need to be part of Package Control.sublime-package. They are added to the .gitattributes file to not export them.