### PR TITLE
Avoid duplicated directory exists checks.

### DIFF
--- a/dev/deps.py
+++ b/dev/deps.py
@@ -290,8 +290,7 @@ def _extract_package(deps_dir, pkg_path, pkg_dir):
                 if data is not None:
                     dst_path = os.path.join(deps_dir, zi.filename[8:])
                     dst_dir = os.path.dirname(dst_path)
-                    if not os.path.exists(dst_dir):
-                        os.makedirs(dst_dir)
+                    os.makedirs(dst_dir, exist_ok=True)
                     with open(dst_path, 'wb') as f:
                         f.write(data)
         finally:
@@ -327,8 +326,7 @@ def _extract_package(deps_dir, pkg_path, pkg_dir):
                 dst_rel_path = dst_rel_path[len(common_root) + 1:]
             members.append((info, dst_rel_path))
 
-        if not os.path.exists(staging_dir):
-            os.makedirs(staging_dir)
+        os.makedirs(staging_dir, exist_ok=True)
 
         for info, rel_path in members:
             info_data = _extract_info(ar, info)
@@ -336,8 +334,7 @@ def _extract_package(deps_dir, pkg_path, pkg_dir):
             if info_data is not None:
                 dst_path = os.path.join(staging_dir, rel_path)
                 dst_dir = os.path.dirname(dst_path)
-                if not os.path.exists(dst_dir):
-                    os.makedirs(dst_dir)
+                os.makedirs(dst_dir, exist_ok=True)
                 with open(dst_path, 'wb') as f:
                     f.write(info_data)
 

--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -1347,13 +1347,11 @@ class PackageManager():
                             break
 
                 if path.endswith('/'):
-                    if not os.path.exists(dest):
-                        os.makedirs(dest)
+                    os.makedirs(dest, exist_ok=True)
                     add_extracted_dirs(dest)
                 else:
                     dest_dir = os.path.dirname(dest)
-                    if not os.path.exists(dest_dir):
-                        os.makedirs(dest_dir)
+                    os.makedirs(dest_dir, exist_ok=True)
                     add_extracted_dirs(dest_dir)
                     extracted_paths.add(dest)
                     try:
@@ -1679,8 +1677,7 @@ class PackageManager():
             backup_dir = os.path.join(os.path.dirname(
                 self.settings['packages_path']), 'Backup',
                 datetime.datetime.now().strftime('%Y%m%d%H%M%S'))
-            if not os.path.exists(backup_dir):
-                os.makedirs(backup_dir)
+            os.makedirs(backup_dir, exist_ok=True)
             package_backup_dir = os.path.join(backup_dir, package_name)
             if os.path.exists(package_backup_dir):
                 console_write(


### PR DESCRIPTION
The `os.makedirs()` function raises an OSError by default if the path already exists. By passing `exist_ok=True` the function fails silently in such cases so no further checks are required.