### PR TITLE
Remove __unicode__() methods

### DIFF
--- a/package_control/clients/client_exception.py
+++ b/package_control/clients/client_exception.py
@@ -2,11 +2,5 @@ class ClientException(Exception):
 
     """If a client could not fetch information"""
 
-    def __unicode__(self):
-        return self.args[0]
-
-    def __str__(self):
-        return self.__unicode__()
-
     def __bytes__(self):
-        return self.__unicode__().encode('utf-8')
+        return self.__str__().encode('utf-8')

--- a/package_control/downloaders/binary_not_found_error.py
+++ b/package_control/downloaders/binary_not_found_error.py
@@ -2,11 +2,5 @@ class BinaryNotFoundError(Exception):
 
     """If a necessary executable is not found in the PATH on the system"""
 
-    def __unicode__(self):
-        return self.args[0]
-
-    def __str__(self):
-        return self.__unicode__()
-
     def __bytes__(self):
-        return self.__unicode__().encode('utf-8')
+        return self.__str__().encode('utf-8')

--- a/package_control/downloaders/downloader_exception.py
+++ b/package_control/downloaders/downloader_exception.py
@@ -2,11 +2,5 @@ class DownloaderException(Exception):
 
     """If a downloader could not download a URL"""
 
-    def __unicode__(self):
-        return self.args[0]
-
-    def __str__(self):
-        return self.__unicode__()
-
     def __bytes__(self):
-        return self.__unicode__().encode('utf-8')
+        return self.__str__().encode('utf-8')

--- a/package_control/downloaders/http_error.py
+++ b/package_control/downloaders/http_error.py
@@ -6,11 +6,5 @@ class HttpError(Exception):
         self.code = code
         super(HttpError, self).__init__(message)
 
-    def __unicode__(self):
-        return self.args[0]
-
-    def __str__(self):
-        return self.__unicode__()
-
     def __bytes__(self):
-        return self.__unicode__().encode('utf-8')
+        return self.__str__().encode('utf-8')

--- a/package_control/downloaders/non_clean_exit_error.py
+++ b/package_control/downloaders/non_clean_exit_error.py
@@ -10,11 +10,8 @@ class NonCleanExitError(Exception):
     def __init__(self, returncode):
         self.returncode = returncode
 
-    def __unicode__(self):
+    def __str__(self):
         return str(self.returncode)
 
-    def __str__(self):
-        return self.__unicode__()
-
     def __bytes__(self):
-        return self.__unicode__().encode('utf-8')
+        return self.__str__().encode('utf-8')

--- a/package_control/downloaders/non_http_error.py
+++ b/package_control/downloaders/non_http_error.py
@@ -2,11 +2,5 @@ class NonHttpError(Exception):
 
     """If a downloader had a non-clean exit, but it was not due to an HTTP error"""
 
-    def __unicode__(self):
-        return self.args[0]
-
-    def __str__(self):
-        return self.__unicode__()
-
     def __bytes__(self):
-        return self.__unicode__().encode('utf-8')
+        return self.__str__().encode('utf-8')

--- a/package_control/http/invalid_certificate_exception.py
+++ b/package_control/http/invalid_certificate_exception.py
@@ -16,11 +16,5 @@ class InvalidCertificateException(HTTPException, URLError):
         message = 'Host %s returned an invalid certificate (%s) %s' % (self.host, self.reason, self.cert)
         HTTPException.__init__(self, message.rstrip())
 
-    def __unicode__(self):
-        return self.args[0]
-
-    def __str__(self):
-        return self.__unicode__()
-
     def __bytes__(self):
-        return self.__unicode__().encode('utf-8')
+        return self.__str__().encode('utf-8')

--- a/package_control/providers/provider_exception.py
+++ b/package_control/providers/provider_exception.py
@@ -2,11 +2,5 @@ class ProviderException(Exception):
 
     """If a provider could not return information"""
 
-    def __unicode__(self):
-        return self.args[0]
-
-    def __str__(self):
-        return self.__unicode__()
-
     def __bytes__(self):
-        return self.__unicode__().encode('utf-8')
+        return self.__str__().encode('utf-8')


### PR DESCRIPTION
As python 3 stores all strings in unicode by default and `unicode()` is not supported anymore, it seems not to be required to maintain `__unicode__()` methods in exception classes. Also use default `__str__()` where possible.