### PR TITLE
Fix/user providers

### DIFF
--- a/package_control/providers/bitbucket_repository_provider.py
+++ b/package_control/providers/bitbucket_repository_provider.py
@@ -130,11 +130,11 @@ class BitBucketRepositoryProvider():
                 yield (key, value)
             return
 
-        client = BitBucketClient(self.settings)
-
         if invalid_sources is not None and self.repo in invalid_sources:
             raise StopIteration()
 
+        client = BitBucketClient(self.settings)
+        
         try:
             repo_info = client.repo_info(self.repo)
 

--- a/package_control/providers/github_repository_provider.py
+++ b/package_control/providers/github_repository_provider.py
@@ -135,10 +135,10 @@ class GitHubRepositoryProvider():
                 yield (key, value)
             return
 
-        client = GitHubClient(self.settings)
-
         if invalid_sources is not None and self.repo in invalid_sources:
             raise StopIteration()
+
+        client = GitHubClient(self.settings)
 
         try:
             repo_info = client.repo_info(self.repo)

--- a/package_control/providers/github_user_provider.py
+++ b/package_control/providers/github_user_provider.py
@@ -136,10 +136,10 @@ class GitHubUserProvider():
 
         try:
             user_repos = client.user_info(self.repo)
-        except (DownloaderException, ClientException, ProviderException) as e:
-            self.failed_sources = [self.repo]
-            self.cache['get_packages'] = e
-            raise e
+        except (DownloaderException, ClientException) as e:
+            self.failed_sources[self.repo] = e
+            self.cache['get_packages'] = {}
+            raise
 
         output = {}
         for repo_info in user_repos:

--- a/package_control/providers/github_user_provider.py
+++ b/package_control/providers/github_user_provider.py
@@ -129,10 +129,10 @@ class GitHubUserProvider():
                 yield (key, value)
             return
 
-        client = GitHubClient(self.settings)
-
         if invalid_sources is not None and self.repo in invalid_sources:
             raise StopIteration()
+
+        client = GitHubClient(self.settings)
 
         try:
             user_repos = client.user_info(self.repo)

--- a/package_control/providers/gitlab_repository_provider.py
+++ b/package_control/providers/gitlab_repository_provider.py
@@ -134,10 +134,10 @@ class GitLabRepositoryProvider():
                 yield (key, value)
             return
 
-        client = GitLabClient(self.settings)
-
         if invalid_sources is not None and self.repo in invalid_sources:
             raise StopIteration()
+
+        client = GitLabClient(self.settings)
 
         try:
             repo_info = client.repo_info(self.repo)

--- a/package_control/providers/gitlab_user_provider.py
+++ b/package_control/providers/gitlab_user_provider.py
@@ -137,10 +137,10 @@ class GitLabUserProvider:
 
         try:
             user_repos = client.user_info(self.repo)
-        except (DownloaderException, ClientException, ProviderException) as e:
-            self.failed_sources = [self.repo]
-            self.cache['get_packages'] = e
-            raise e
+        except (DownloaderException, ClientException) as e:
+            self.failed_sources[self.repo] = e
+            self.cache['get_packages'] = {}
+            raise
 
         output = {}
         for repo_info in user_repos:

--- a/package_control/providers/gitlab_user_provider.py
+++ b/package_control/providers/gitlab_user_provider.py
@@ -130,10 +130,10 @@ class GitLabUserProvider:
                 yield (key, value)
             return
 
-        client = GitLabClient(self.settings)
-
         if invalid_sources is not None and self.repo in invalid_sources:
             raise StopIteration()
+
+        client = GitLabClient(self.settings)
 
         try:
             user_repos = client.user_info(self.repo)


### PR DESCRIPTION
This PR proposes to...

1. move client instantiation in `...RepositoryProviders` to a position when it is clear they are needed.
2. fix an issue in GitHubUserProvider/GitLabUserProvider which assigns wrong values to `failed_resources` and `cache` in case of client failing to download user information.

