### PR TITLE
Fix http cache path creation

### DIFF
--- a/package_control/http_cache.py
+++ b/package_control/http_cache.py
@@ -14,8 +14,7 @@ class HttpCache(object):
 
     def __init__(self, ttl):
         self.base_path = os.path.join(pc_cache_dir(), 'http_cache')
-        if not os.path.exists(self.base_path):
-            os.mkdir(self.base_path)
+        os.makedirs(self.base_path, exist_ok=True)
         self.clear(int(ttl))
 
     def clear(self, ttl):


### PR DESCRIPTION
Fixes https://github.com/sublimehq/sublime_text/issues/3964

This PR fixes an error which causes http_cache folder not to be created in case the whole Cache/Package Control path was removed during runtime.