### PR TITLE
Fix cli_downloader on Windows

### DIFF
--- a/package_control/downloaders/cli_downloader.py
+++ b/package_control/downloaders/cli_downloader.py
@@ -43,13 +43,16 @@ class CliDownloader(object):
             # This is mostly for OS X, which seems to launch ST with a
             # minimal set of environmental variables
             dirs.append('/usr/local/bin')
+            executable = name
+        else:
+            executable = name + ".exe"
 
         for dir_ in dirs:
-            path = os.path.join(dir_, name)
+            path = os.path.join(dir_, executable)
             if os.path.exists(path):
                 return path
 
-        raise BinaryNotFoundError('The binary %s could not be located' % name)
+        raise BinaryNotFoundError('The binary %s could not be located' % executable)
 
     def execute(self, args):
         """
@@ -73,7 +76,13 @@ class CliDownloader(object):
                 create_cmd(args)
             )
 
-        proc = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        startupinfo = None
+        if os.name == 'nt':
+            startupinfo = subprocess.STARTUPINFO()
+            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+
+        proc = subprocess.Popen(
+            args, startupinfo=startupinfo, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         output = proc.stdout.read()
         self.stderr = proc.stderr.read()

--- a/package_control/downloaders/cli_downloader.py
+++ b/package_control/downloaders/cli_downloader.py
@@ -84,11 +84,10 @@ class CliDownloader(object):
         proc = subprocess.Popen(
             args, startupinfo=startupinfo, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
-        output = proc.stdout.read()
-        self.stderr = proc.stderr.read()
-        returncode = proc.wait()
-        if returncode != 0:
-            error = NonCleanExitError(returncode)
+        output, self.stderr = proc.communicate()
+
+        if proc.returncode != 0:
+            error = NonCleanExitError(proc.returncode)
             error.stderr = self.stderr
             error.stdout = output
             raise error


### PR DESCRIPTION
This PR enables usage of cli_downloader on Windows OS by fixing 2 issues.

First of them prevented `curl.exe` or `wget.exe` from being found by `find_binary()` method as it missed to add the file extension.

Second fix addresses an issue with console window being displayed if an executable is invoked, which caused bad user experience.

curl.exe is shipped by default as of Windows 10 and therefore might be used as downloader. May be quite uncommon as the others do a good job, but if someone decides to use it, it should work.