### PR TITLE
Use Lock Context Manager in downloader

### DIFF
--- a/package_control/download_manager.py
+++ b/package_control/download_manager.py
@@ -50,8 +50,7 @@ def downloader(url, settings):
 def _grab(url, settings):
     global _managers, _lock, _in_use, _timer
 
-    _lock.acquire()
-    try:
+    with _lock:
         if _timer:
             _timer.cancel()
             _timer = None
@@ -70,15 +69,11 @@ def _grab(url, settings):
 
         return _managers[hostname].pop()
 
-    finally:
-        _lock.release()
-
 
 def _release(url, manager):
     global _managers, _lock, _in_use, _timer
 
-    _lock.acquire()
-    try:
+    with _lock:
         hostname = urlparse(url).hostname.lower()
 
         # This means the package was reloaded between _grab and _release,
@@ -98,15 +93,11 @@ def _release(url, manager):
             _timer = Timer(5.0, close_all_connections)
             _timer.start()
 
-    finally:
-        _lock.release()
-
 
 def close_all_connections():
     global _managers, _lock, _in_use, _timer
 
-    _lock.acquire()
-    try:
+    with _lock:
         if _timer:
             _timer.cancel()
             _timer = None
@@ -115,9 +106,6 @@ def close_all_connections():
             for manager in managers:
                 manager.close()
         _managers = {}
-
-    finally:
-        _lock.release()
 
 
 def update_url(url, debug):


### PR DESCRIPTION
This PR replaces `try..finally` blocks by `with _lock` in download_manager module to save some lines of code. It doesn't have any functional effect but seems a bit more pythonic.

That's possible as python 2.6 support is dropped.