### PR TITLE
Fix missing cache_length in DownloadManager

### DIFF
--- a/package_control/download_manager.py
+++ b/package_control/download_manager.py
@@ -161,6 +161,7 @@ class DownloadManager(object):
         if settings.get('http_cache'):
             cache_length = settings.get('http_cache_length', 604800)
             self.settings['cache'] = HttpCache(cache_length)
+            self.settings['cache_length'] = cache_length
 
     def close(self):
         if self.downloader:


### PR DESCRIPTION
This commit adds `cache_length` to internal settings as this key is queried every time a downloader calls `set_cache()` functions.

The missing value results in cache module always applying a TTL of 300s instead of the value from Package Control.sublime-settings.

This results in HTTP queries after 5mins, which all result in 304 with cached values from HttpCache being used and reparsed. This should happen only if ST was closed.