### PR TITLE
Don't run the same job twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,12 @@
 name: CI
-on: [push, pull_request]
+
+on:
+  push:
+    branches:
+      - four-point-oh
+  pull_request:
+    branches:
+      - four-point-oh
 
 jobs:
   build:


### PR DESCRIPTION
This should make the GitHub action runner run only once (per matrix configuration).