### PR TITLE
Fix Version Selector

### DIFF
--- a/package_control/commands/package_control_tests_command.py
+++ b/package_control/commands/package_control_tests_command.py
@@ -11,6 +11,7 @@ from ..tests.providers import (
     GitLabRepositoryProviderTests,
     GitLabUserProviderTests,
     RepositoryProviderTests,
+    VersionSelectorTests,
 )
 
 
@@ -31,7 +32,8 @@ class PackageControlTestsCommand(sublime_plugin.WindowCommand):
                 GitLabRepositoryProviderTests,
                 GitLabUserProviderTests,
                 RepositoryProviderTests,
-                ChannelProviderTests
+                ChannelProviderTests,
+                VersionSelectorTests,
             ]
         )
 

--- a/package_control/package_cleanup.py
+++ b/package_control/package_cleanup.py
@@ -391,7 +391,7 @@ class PackageCleanup(threading.Thread):
         if not sublime_text and not platforms:
             return True
 
-        if not is_compatible_version(sublime_text):
+        if not is_compatible_version(sublime_text, int(sublime.version())):
             return False
 
         if not isinstance(platforms, list):

--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -380,6 +380,8 @@ class PackageManager():
             '*'
         ]
 
+        st_version = self.settings['version']
+
         for platform_selector in platform_selectors:
             if platform_selector not in dependency_info:
                 continue
@@ -389,7 +391,7 @@ class PackageManager():
 
             # Sorting reverse will give us >, < then *
             for version_selector in sorted(versions, reverse=True):
-                if not is_compatible_version(version_selector):
+                if not is_compatible_version(version_selector, st_version):
                     continue
                 return platform_dependency[version_selector]
 

--- a/package_control/providers/release_selector.py
+++ b/package_control/providers/release_selector.py
@@ -86,9 +86,9 @@ def is_compatible_version(version_range):
     else:
         return None
 
-    if min_version > int(sublime.version()):
+    if min_version >= int(sublime.version()):
         return False
-    if max_version < int(sublime.version()):
+    if max_version <= int(sublime.version()):
         return False
 
     return True

--- a/package_control/tests/__init__.py
+++ b/package_control/tests/__init__.py
@@ -20,6 +20,7 @@ TEST_CLASSES = [
     providers.GitLabUserProviderTests,
     providers.RepositoryProviderTests,
     providers.ChannelProviderTests,
+    providers.VersionSelectorTests
 ]
 
 

--- a/package_control/tests/providers.py
+++ b/package_control/tests/providers.py
@@ -7,6 +7,7 @@ from ..providers.github_user_provider import GitHubUserProvider
 from ..providers.gitlab_repository_provider import GitLabRepositoryProvider
 from ..providers.gitlab_user_provider import GitLabUserProvider
 from ..providers.bitbucket_repository_provider import BitBucketRepositoryProvider
+from ..providers.release_selector import is_compatible_version
 from ..http_cache import HttpCache
 
 from . import LAST_COMMIT_TIMESTAMP, LAST_COMMIT_VERSION, CLIENT_ID, CLIENT_SECRET
@@ -2217,3 +2218,44 @@ class ChannelProviderTests(unittest.TestCase):
                 "https://raw.githubusercontent.com/wbond/package_control-json/master/repository-3.0.0-explicit.json"
             )
         )
+
+
+class VersionSelectorTests(unittest.TestCase):
+
+    def test_version_less_than(self):
+        self.assertTrue(is_compatible_version("<3176", 3175))
+
+    def test_version_not_less_than(self):
+        self.assertFalse(is_compatible_version("<3176", 3176))
+
+    def test_version_less_or_equal_than(self):
+        self.assertTrue(is_compatible_version("<=3176", 3175))
+        self.assertTrue(is_compatible_version("<=3176", 3176))
+
+    def test_version_not_less_or_equal_than(self):
+        self.assertFalse(is_compatible_version("<=3176", 3177))
+
+    def test_version_greater_than(self):
+        self.assertTrue(is_compatible_version(">3176", 3177))
+
+    def test_version_not_greater_than(self):
+        self.assertFalse(is_compatible_version(">3176", 3176))
+
+    def test_version_greater_or_equal_than(self):
+        self.assertTrue(is_compatible_version(">=3176", 3176))
+        self.assertTrue(is_compatible_version(">=3176", 3177))
+
+    def test_version_not_greater_or_equal_than(self):
+        self.assertFalse(is_compatible_version(">=3176", 3175))
+
+    def test_version_range_below_lower_bound(self):
+        self.assertFalse(is_compatible_version("3176 - 3211", 3175))
+
+    def test_version_range_lower_bound(self):
+        self.assertTrue(is_compatible_version("3176 - 3211", 3176))
+
+    def test_version_range_upper_bound(self):
+        self.assertTrue(is_compatible_version("3176 - 3211", 3211))
+
+    def test_version_range_above_upper_bound(self):
+        self.assertFalse(is_compatible_version("3176 - 3211", 3212))


### PR DESCRIPTION
Fixes #1578

A range selector is an greater than or equal and smaller than or equal operation, which includes provided min/max boundaries into valid range.

It turned out `is_compatible_version()` handles `>=` vs. `>` and `<=` vs. `<` wrong in general.

Note: Not sure if this is to be handled as hofix for current release or whether should be merged to four-point-oh only.