### PR TITLE
fix: HTML decoding error in QuickPanelItem

### DIFF
--- a/package_control/commands/existing_packages_command.py
+++ b/package_control/commands/existing_packages_command.py
@@ -62,7 +62,10 @@ class ExistingPackagesCommand():
                 description = '<em>%s</em>' % sublime.html_format_command(description)
                 final_line = '<em>' + action + installed_version + '</em>'
                 if url_display:
-                    final_line += '; <a href="%s">%s</a>' % (url, url_display)
+                    final_line += '; <a href="%s">%s</a>' % (
+                        sublime.html_format_command(url),
+                        sublime.html_format_command(url_display),
+                    )
                 package_entry = sublime.QuickPanelItem(package, [description, final_line])
             else:
                 final_line = action + installed_version

--- a/package_control/package_installer.py
+++ b/package_control/package_installer.py
@@ -143,7 +143,10 @@ class PackageInstaller(PackageDisabler):
                 if homepage_display:
                     if action or extra:
                         final_line += ' '
-                    final_line += '<a href="%s">%s</a>' % (homepage, homepage_display)
+                    final_line += '<a href="%s">%s</a>' % (
+                        sublime.html_format_command(homepage),
+                        sublime.html_format_command(homepage_display),
+                    )
                 package_entry = sublime.QuickPanelItem(package, [description, final_line])
             else:
                 package_entry = [package]


### PR DESCRIPTION
There are some special chars in the URL.

## Reproduction Steps

1. Open command palette
2. Run `Package Control: Install Package`
3. Type `autos` for filtering
4. Check your console

![image](https://user-images.githubusercontent.com/6594915/125637705-9eb8800a-0fe6-4873-b2d1-12a85410eac5.png)

## Env

PC: `3.4.1`
ST: 4113 Win64
