### PR TITLE
Fix client side basic auth

### DIFF
--- a/package_control/downloaders/wininet_downloader.py
+++ b/package_control/downloaders/wininet_downloader.py
@@ -272,12 +272,12 @@ class WinINetDownloader(DecodingDownloader, LimitingDownloader, CachingDownloade
         username = url_info.username
         password = url_info.password
 
-        if not username and not password:
-            username, password = self.get_username_password(url)
-
         request_headers = {
             'Accept-Encoding': self.supported_encodings()
         }
+        if not username and not password:
+            request_headers.update(self.build_auth_header(url))
+
         request_headers = self.add_conditional_headers(url, request_headers)
 
         created_connection = False

--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -87,6 +87,7 @@ class PackageManager():
             'git_update_command',
             'hg_binary',
             'hg_update_command',
+            'http_basic_auth',
             'http_cache',
             'http_cache_length',
             'http_proxy',


### PR DESCRIPTION
This PR fixes two bugs related with basic authentication:

1. The `http_basic_auth` setting is not cached by PackageManager and therefore not passed to downloaders.
2. Basic authentication doesn't work for WinINetDownloader

As a result users with numerous custom repositories might quickly hit rather low API rate limits.