### PR TITLE
Add caption for Tools submenu

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -3,6 +3,7 @@
         "id": "tools",
         "children": [
             {
+                "caption": "Packages",
                 "id": "packages",
                 "children": [
                     {


### PR DESCRIPTION
The new submenu in Tools is appearing as an empty entry. To prevent this, a caption has been added.