### PR TITLE
Fix ignored_packages setting getting changed at startup if default packages have been extracted

### DIFF
--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -797,6 +797,7 @@ class PackageManager:
         """
 
         packages = set(list_sublime_package_files(sys_path.default_packages_path()))
+        packages |= set(list_sublime_package_dirs(sys_path.default_packages_path()))
         packages -= {'User'}
         return packages
 


### PR DESCRIPTION
If the default packages aren't in a `.sublime-package` file then on startup the `"ignored_packages"` setting would always be set to `[]`.

Primarily this fixes our development environment where we don't use any `.sublime-package` files, but presumably there are also people who've extracted these folders (as unwise as that may be).