### PR TITLE
#1663 Fix python 3.8 dependencies being overwritten by 3.3

### DIFF
--- a/package_control/providers/channel_provider.py
+++ b/package_control/providers/channel_provider.py
@@ -403,7 +403,7 @@ class ChannelProvider:
             for library in chain(*libraries_cache.values()):
                 del library['load_order']
                 for release in library['releases']:
-                    release['python_versions'] = ['3.3']
+                    release['python_versions'] = release.get('python_versions', ['3.3'])
                 library['releases'] = version_sort(library['releases'], 'platforms', reverse=True)
 
         else:


### PR DESCRIPTION
Fix #1663

When a dependency sets `'python_versions'`, it is overwritten by 3.3 only.