### PR TITLE
Disable OscryptoDownloader on python 3.8

### DIFF
--- a/package_control/downloaders/__init__.py
+++ b/package_control/downloaders/__init__.py
@@ -13,12 +13,14 @@ DOWNLOADERS = {
     'wget': WgetDownloader
 }
 
-# oscrypto can fail badly on Linux in the Sublime Text 3 environment due to
-# trying to mix the statically-linked OpenSSL in plugin_host with the OpenSSL
-# loaded from the operating system. On Python 3.8 we dynamically link OpenSSL,
-# so it just needs to be configured properly, which is handled in
-# oscrypto_downloader.py.
-if sys.platform != 'linux' or sys.version_info[:2] != (3, 3) or sys.executable != 'python3':
+# oscrypto can fail badly
+# 1. on Linux in the Sublime Text 3 environment due to trying to mix the
+#    statically-linked OpenSSL in plugin_host with the OpenSSL loaded from the
+#    operating system. On Python 3.8 we dynamically link OpenSSL, so it just needs
+#    to be configured properly, which is handled in oscrypto_downloader.py.
+# 2. on MacOS ARM plattform due to whatever reason. Due to maintanance state of
+#    oscrypto, start fading it out by disabling it on python 3.8 (ST4)
+if sys.platform != 'linux' and sys.version_info[:2] == (3, 3):
     try:
         from .oscrypto_downloader import OscryptoDownloader
         DOWNLOADERS['oscrypto'] = OscryptoDownloader


### PR DESCRIPTION
caused by #1676

This PR ...
1. starts fading out OscryptoDownloader by disabling it on python 3.8 (aka ST4) platforms.
2. fixes original logic to disable OscryptoDownloader for ST3 on linux.

Reasons:

1. OscryptoDownloader relies on [oscrypto](https://pypi.org/project/oscrypto/) which hasn't seen any viable updates for about 2 years at the time of writing this.
3. MacOS related CI tests for python 3.8 start failing as Github Actions moved to ARM platform. The downloader just gets stuck without any error messages.

