### PR TITLE
Drop dummy test cases

### DIFF
--- a/package_control/tests/test_downloaders.py
+++ b/package_control/tests/test_downloaders.py
@@ -143,13 +143,8 @@ class WgetDownloaderTests(unittest.TestCase, DownloaderTestsMixin):
 if hasattr(downloaders, 'OscryptoDownloader'):
     class OscryptoDownloaderTests(unittest.TestCase, DownloaderTestsMixin):
         downloader_class = downloaders.OscryptoDownloader
-else:
-    class OscryptoDownloaderTests(unittest.TestCase):
-        pass
+
 
 if hasattr(downloaders, 'WinINetDownloader'):
     class WinINetDownloaderTests(unittest.TestCase, DownloaderTestsMixin):
         downloader_class = downloaders.WinINetDownloader
-else:
-    class WinINetDownloaderTests(unittest.TestCase):
-        pass


### PR DESCRIPTION
As commit d5ed19bbfd6cc5a88f280fcd6635edfb494b93f3 introduced dynamic test case discovery using `unittest` default mechanisms, creation of dummy test cases for unavailable is obsolete and therefore removed.