### PR TITLE
Fix treatment of unmanaged libraries

### DIFF
--- a/package_control/distinfo.py
+++ b/package_control/distinfo.py
@@ -222,6 +222,28 @@ class DistInfoDir:
 
         return "Package Control\n"
 
+    def add_installer_to_record(self):
+        R"""
+        Add INSTALLER entry to .dist-info/RECORD file.
+
+        Note: hash has been pre-compiled using...
+
+        ```py
+        digest = hashlib.sha256("Package Control\n".encode("utf-8")).digest()
+        sha = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("utf-8")
+        ```
+        """
+        installer = self.dir_name + "/INSTALLER,"
+        record = self.abs_path("RECORD")
+
+        # make sure not to add duplicate entries
+        with open(record, "r", encoding="utf-8") as fobj:
+            items = [item for item in fobj.readlines() if not item.startswith(installer)]
+            items.append(installer + "sha256=Hg_Q6w_I4zpFfb6C24LQdd4oTAMHJZDk9gtuV2yOgkw,16\n")
+
+        with open(record, "w", encoding="utf-8", newline="\n") as fobj:
+            fobj.writelines(sorted(items))
+
     def generate_record(self, package_dirs, package_files):
         """
         Generates the .dist-info/RECORD file contents

--- a/package_control/distinfo.py
+++ b/package_control/distinfo.py
@@ -378,9 +378,11 @@ class DistInfoDir:
         :returns:
             An unicode string of of which installer was used.
         """
-
-        with open(self.abs_path("INSTALLER"), "r", encoding="utf-8") as fobj:
-            return fobj.readline().strip()
+        try:
+            with open(self.abs_path("INSTALLER"), "r", encoding="utf-8") as fobj:
+                return fobj.readline().strip()
+        except FileNotFoundError:
+            return ""
 
     def write_installer(self):
         """

--- a/package_control/library.py
+++ b/package_control/library.py
@@ -141,6 +141,12 @@ class InstalledLibrary(Library):
         self.dist_name = dist_info_dir[: dist_info_dir.find("-")].lower()
         self.python_version = python_version
 
+    def is_managed(self):
+        """
+        Library was installed and is therefore managed by Package Control.
+        """
+        return self.dist_info.read_installer() == self.dist_info.generate_installer().strip()
+
 
 def list_all():
     """

--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -1158,6 +1158,13 @@ class PackageManager:
                 installed_version = pep440.PEP440Version(installed_version)
 
         is_upgrade = installed_library is not None
+        if is_upgrade and not installed_library.is_managed():
+            if debug:
+                console_write(
+                    'The library "%s" for Python %s was not installed by Package Control; leaving alone',
+                    (lib.name, lib.python_version)
+                )
+            return True
 
         release = None
         available_version = None

--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -1275,6 +1275,9 @@ class PackageManager:
                     )
                     return False
 
+                temp_did.write_installer()
+                temp_did.add_installer_to_record()
+
                 try:
                     temp_did.verify_python_version(lib.python_version)
                 except EnvironmentError as e:

--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -958,8 +958,8 @@ class PackageManager:
         installed_libraries = self.list_libraries()
         if required_libraries is None:
             required_libraries = self.find_required_libraries()
-        unmanaged_libraries = library.list_unmanaged()
-        return installed_libraries - required_libraries - unmanaged_libraries
+
+        return set(lib for lib in installed_libraries - required_libraries if lib.is_managed())
 
     def _download_zip_file(self, name, url, sha256=None):
         try:

--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -1128,7 +1128,7 @@ class PackageManager:
         """
 
         error = False
-        for lib in libraries:
+        for lib in sorted(libraries):
             if not self.install_library(lib):
                 if fail_early:
                     return False
@@ -1351,7 +1351,7 @@ class PackageManager:
         orphaned_libraries = self.find_orphaned_libraries(required_libraries)
 
         error = False
-        for lib in orphaned_libraries:
+        for lib in sorted(orphaned_libraries):
             if not self.remove_library(lib):
                 error = True
 


### PR DESCRIPTION
This PR...

1. fixes INSTALLER not being added when installing wheels
2. auto-fixes missing INSTALLER file at startup  
   It affects only non-manipulated libraries. Manually removing INSTALLER still marks a package unmaintained as expected.
3. avoid duplicate filesystem traversals to determine managed packages