### PR TITLE
Fix package control not working in development environment

### DIFF
--- a/package_control/sys_path.py
+++ b/package_control/sys_path.py
@@ -14,6 +14,11 @@ if not __executable_path:
 # Default packages are located in application installation directory next to executables.
 __default_packages_path = os.path.join(os.path.dirname(__executable_path), 'Packages')
 if not os.path.isdir(__default_packages_path):
+    # Fall back to detecting the path using the location of the module
+    import Default.sort as default_module
+    __default_packages_path = os.path.dirname(os.path.dirname(default_module.__file__))
+
+if not os.path.isdir(__default_packages_path):
     raise FileNotFoundError('Default Packages')
 
 # Determine user's data path.


### PR DESCRIPTION
The default packages in our development environment are not next to the executable, so the new path detection algorithm doesn't work. Not sure if this affects anyone else.