### PR TITLE
Teach `http_get` to read "file:///" urls

### DIFF
--- a/package_control/commands/add_channel_command.py
+++ b/package_control/commands/add_channel_command.py
@@ -30,7 +30,7 @@ class AddChannelCommand(sublime_plugin.ApplicationCommand):
         if isinstance(url, str):
             url = url.strip()
 
-            if re.match(r'https?://', url, re.I) is None:
+            if re.match(r'^(?:file:///|https?://)', url, re.I) is None:
                 output_fn = console_write if unattended else show_error
                 output_fn(
                     '''

--- a/package_control/commands/add_repository_command.py
+++ b/package_control/commands/add_repository_command.py
@@ -30,7 +30,7 @@ class AddRepositoryCommand(sublime_plugin.ApplicationCommand):
         if isinstance(url, str):
             url = url.strip()
 
-            if re.match(r'https?://', url, re.I) is None:
+            if re.match(r'^(?:file:///|https?://)', url, re.I) is None:
                 output_fn = console_write if unattended else show_error
                 output_fn(
                     '''

--- a/package_control/commands/existing_packages_command.py
+++ b/package_control/commands/existing_packages_command.py
@@ -29,7 +29,7 @@ class ExistingPackagesCommand(sublime_plugin.ApplicationCommand):
         default_packages = manager.list_default_packages()
         default_version = 'built-in v' + sublime.version()
 
-        url_pattern = re.compile(r'^https?://')
+        url_pattern = re.compile(r'^(?:file:///|https?://)')
 
         package_list = []
         for package in sorted(self.list_packages(manager), key=lambda s: s.lower()):

--- a/package_control/download_manager.py
+++ b/package_control/download_manager.py
@@ -3,7 +3,7 @@ import re
 import socket
 import sys
 from threading import Lock, Timer
-from urllib.parse import urljoin, urlparse
+from urllib.parse import unquote, urljoin, urlparse
 
 from . import __version__
 from . import text
@@ -67,6 +67,9 @@ def http_get(url, settings, error_message='', prefer_cached=False):
     :return:
         The string contents of the URL
     """
+    if url.startswith("file:///"):
+        with open(unquote(url[8:]), "rb") as f:
+            return f.read()
 
     manager = None
     result = None

--- a/package_control/download_manager.py
+++ b/package_control/download_manager.py
@@ -67,9 +67,13 @@ def http_get(url, settings, error_message='', prefer_cached=False):
     :return:
         The string contents of the URL
     """
-    if url.startswith("file:///"):
-        with open(unquote(url[8:]), "rb") as f:
-            return f.read()
+
+    if url[:8].lower() == "file:///":
+        try:
+            with open(unquote(url[8:]), "rb") as f:
+                return f.read()
+        except OSError as e:
+            raise DownloaderException(str(e))
 
     manager = None
     result = None
@@ -175,11 +179,7 @@ def resolve_urls(root_url, uris):
         A generator of resolved URLs
     """
 
-    scheme_match = re.match(r'(https?:)//', root_url, re.I)
-    if scheme_match is None:
-        root_dir = os.path.dirname(root_url)
-    else:
-        root_dir = ''
+    scheme_match = re.match(r'^(file:/|https?:)//', root_url, re.I)
 
     for url in uris:
         if not url:
@@ -193,10 +193,7 @@ def resolve_urls(root_url, uris):
             # We don't allow absolute repositories
             continue
         elif url.startswith('./') or url.startswith('../'):
-            if root_dir:
-                url = os.path.normpath(os.path.join(root_dir, url))
-            else:
-                url = urljoin(root_url, url)
+            url = urljoin(root_url, url)
         yield url
 
 
@@ -217,23 +214,15 @@ def resolve_url(root_url, url):
     if not url:
         return url
 
-    scheme_match = re.match(r'(https?:)//', root_url, re.I)
-    if scheme_match is None:
-        root_dir = os.path.dirname(root_url)
-    else:
-        root_dir = ''
-
     if url.startswith('//'):
+        scheme_match = re.match(r'^(file:/|https?:)//', root_url, re.I)
         if scheme_match is not None:
             return scheme_match.group(1) + url
         else:
             return 'https:' + url
 
     elif url.startswith('./') or url.startswith('../'):
-        if root_dir:
-            return os.path.normpath(os.path.join(root_dir, url))
-        else:
-            return urljoin(root_url, url)
+        return urljoin(root_url, url)
 
     return url
 

--- a/package_control/providers/channel_provider.py
+++ b/package_control/providers/channel_provider.py
@@ -99,25 +99,7 @@ class ChannelProvider:
         if self.repositories is not None:
             return
 
-        if re.match(r'https?://', self.channel_url, re.I):
-            json_string = http_get(self.channel_url, self.settings, 'Error downloading channel.')
-
-        # All other channels are expected to be filesystem paths
-        else:
-            if not os.path.exists(self.channel_url):
-                raise ProviderException('Error, file %s does not exist' % self.channel_url)
-
-            if self.settings.get('debug'):
-                console_write(
-                    '''
-                    Loading %s as a channel
-                    ''',
-                    self.channel_url
-                )
-
-            # We open as binary so we get bytes like the DownloadManager
-            with open(self.channel_url, 'rb') as f:
-                json_string = f.read()
+        json_string = http_get(self.channel_url, self.settings, 'Error downloading channel.')
 
         try:
             channel_info = json.loads(json_string.decode('utf-8'))

--- a/package_control/providers/json_repository_provider.py
+++ b/package_control/providers/json_repository_provider.py
@@ -130,25 +130,7 @@ class JsonRepositoryProvider(BaseRepositoryProvider):
 
         self.included_urls.add(location)
 
-        if re.match(r'https?://', location, re.I):
-            json_string = http_get(location, self.settings, 'Error downloading repository.')
-
-        # Anything that is not a URL is expected to be a filesystem path
-        else:
-            if not os.path.exists(location):
-                raise ProviderException('Error, file %s does not exist' % location)
-
-            if self.settings.get('debug'):
-                console_write(
-                    '''
-                    Loading %s as a repository
-                    ''',
-                    location
-                )
-
-            # We open as binary so we get bytes like the DownloadManager
-            with open(location, 'rb') as f:
-                json_string = f.read()
+        json_string = http_get(location, self.settings, 'Error downloading repository.')
 
         try:
             repo_info = json.loads(json_string.decode('utf-8'))


### PR DESCRIPTION
We can already host local repositories -- i.e. "repositories" in the PC settings understand absolute local paths as additional repositories. But then inside such a repository, we cannot point a release url to a local file but MUST use the http-protocol.

E.g. for testing purposes, that means to create a local file server just to host such release-zip files.

See https://github.com/SublimeLinter/SublimeLinter/blob/029ff3dcf441f5606ecb329d66d76ed7df601e96/scripts/repo.json#L14-L14 Over there, I just use "python -m http.server 8000" to host a folder that contains SublimeLinter releases.

That seems unnecessary as the "file:///"-scheme denotes a local file expressed as an url, and frankly, other fetchers would accept them just as-is.  E.g. a simple `urllib.request.urlopen(location)` would work with both http and file urls.

It doesn't work here because of basic tests in `_grab`, namely:

```
        parsed = urlparse(url)
        if not parsed or not parsed.hostname:
            raise DownloaderException('The URL "%s" is malformed' % url)
```

Don't scratch that test but instead check for the "file:///" scheme at the top, and do a straight, dead-simple `file.open` instead.

That's the minimal patch to support the usecase.