### PR TITLE
Do not cache "file:///" resources

### DIFF
--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -493,7 +493,10 @@ class PackageManager:
 
             # Caches various info from channels for performance
             cache_key = channel + '.repositories'
-            channel_repositories = get_cache(cache_key)
+            if channel[:8].lower() == "file:///":
+                channel_repositories = None
+            else:
+                channel_repositories = get_cache(cache_key)
 
             merge_cache_under_settings(self, 'renamed_packages', channel)
             merge_cache_under_settings(self, 'unavailable_packages', channel, list_=True)
@@ -636,17 +639,20 @@ class PackageManager:
                 console_write('Removed malicious repository %s' % repo)
                 continue
 
-            cache_key = repo + '.packages'
-            repository_packages = get_cache(cache_key)
+            if repo[:8].lower() == "file:///":
+                repository_packages = None
+                repository_libraries = None
+            else:
+                cache_key = repo + '.packages'
+                repository_packages = get_cache(cache_key)
 
-            if repository_packages:
-                packages.update(repository_packages)
+                if repository_packages:
+                    packages.update(repository_packages)
 
-            cache_key = repo + '.libraries'
-            repository_libraries = get_cache(cache_key)
-
-            if repository_libraries:
-                libraries.update(repository_libraries)
+                cache_key = repo + '.libraries'
+                repository_libraries = get_cache(cache_key)
+                if repository_libraries:
+                    libraries.update(repository_libraries)
 
             if repository_packages is None and repository_libraries is None:
                 if executor is None:


### PR DESCRIPTION
Fixes #1695

We generally cache to save the network latency, not because our transformations of the data were so expensive.

We expect that "file:///" protocol resources can be read fast enough for our purposes and want to ensure that changes of such local files are available immediately, e.g. without restart Sublime Text or clearing the cache as a whole (`clear_cache`).

Note that we only refuse to read from the cache (`get_cache`) and thus imitate a fresh install.  We still write to the cache in case that is observable by other parts of our source code.