### PR TITLE
Host main channel.json as GitHub release asset

### DIFF
--- a/.github/workflows/publish_channel.yml
+++ b/.github/workflows/publish_channel.yml
@@ -19,14 +19,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.13'
 
       - name: Generate new channel.json
         id: generate
         run: |
-          curl -s -L -o channel.json https://packagecontrol.io/channel_v3.json
+          python scripts/generate_channel.py
           # Verify the file was created
           if [ ! -f "channel.json" ]; then
             echo "Error: channel.json was not generated"

--- a/.github/workflows/publish_channel.yml
+++ b/.github/workflows/publish_channel.yml
@@ -1,0 +1,88 @@
+name: Publish channel.json Asset
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  RELEASE_TAG: channel-latest
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Generate new channel.json
+        id: generate
+        run: |
+          curl -s -L -o channel.json https://packagecontrol.io/channel_v3.json
+          # Verify the file was created
+          if [ ! -f "channel.json" ]; then
+            echo "Error: channel.json was not generated"
+            exit 1
+          fi
+
+          # Calculate hash of new file
+          NEW_HASH=$(sha256sum channel.json | cut -d ' ' -f 1)
+          echo "new_hash=$NEW_HASH" >> $GITHUB_OUTPUT
+          echo "New channel.json hash: $NEW_HASH"
+
+      - name: Try to download existing channel.json
+        id: download
+        continue-on-error: true
+        run: |
+          curl -s -L -o existing-channel.json https://github.com/${{ github.repository }}/releases/download/${{ env.RELEASE_TAG }}/channel.json || echo "First run or download failed"
+          if [ -f "existing-channel.json" ]; then
+            EXISTING_HASH=$(sha256sum existing-channel.json | cut -d ' ' -f 1)
+            echo "existing_hash=$EXISTING_HASH" >> $GITHUB_OUTPUT
+            echo "Existing channel.json hash: $EXISTING_HASH"
+          else
+            echo "No existing channel.json found or download failed"
+            echo "existing_hash=none" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Determine if update is needed
+        id: check
+        run: |
+          # If first run or hashes differ, update is needed
+          if [ "${{ steps.download.outputs.existing_hash }}" != "${{ steps.generate.outputs.new_hash }}" ]; then
+            echo "update_needed=true" >> $GITHUB_OUTPUT
+            echo "Update needed: Content has changed or first run"
+          else
+            echo "update_needed=false" >> $GITHUB_OUTPUT
+            echo "No update needed: Content is unchanged"
+          fi
+
+      - name: Update release and upload asset if needed
+        if: steps.check.outputs.update_needed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Create or update the release
+          gh release view ${{ env.RELEASE_TAG }} || \
+          gh release create ${{ env.RELEASE_TAG }} \
+            --title "Channel Asset" \
+            --notes "Latest channel.json"
+
+          echo "Uploading channel.json file..."
+          gh release upload ${{ env.RELEASE_TAG }} channel.json \
+            --clobber
+
+      - name: Output result
+        run: |
+          if [ "${{ steps.check.outputs.update_needed }}" = "true" ]; then
+            echo "✅ Channel updated with new content"
+          else
+            echo "ℹ️ No changes detected in channel.json, skipped update"
+          fi

--- a/Package Control.sublime-settings
+++ b/Package Control.sublime-settings
@@ -3,11 +3,8 @@
 	// The repositories from these channels are placed in order after the
 	// repositories from the "repositories" setting
 	"channels": [
-		// channel_v4 for python 3.8 compatible libraries to enable plugins
-		// to migrate to python 3.8 until packagecontrol.io supports new scheme.
-		// Note: Must always be located before default channel in the list!
+		// default channel for packages
 		// Repo: https://github.com/packagecontrol/channel
-		"https://packagecontrol.github.io/channel/channel_v4.json",
 		// default channel for packages
 		// Repo: https://github.com/wbond/package_control_channel
 		"https://github.com/wbond/package_control/releases/download/channel-latest/channel.json"

--- a/Package Control.sublime-settings
+++ b/Package Control.sublime-settings
@@ -10,7 +10,7 @@
 		"https://packagecontrol.github.io/channel/channel_v4.json",
 		// default channel for packages
 		// Repo: https://github.com/wbond/package_control_channel
-		"https://packagecontrol.io/channel_v3.json"
+		"https://github.com/wbond/package_control/releases/download/channel-latest/channel.json"
 	],
 
 	// A list of URLs that contain a packages JSON file or point to a

--- a/scripts/generate_channel.py
+++ b/scripts/generate_channel.py
@@ -1,20 +1,36 @@
 from __future__ import annotations
 
+from itertools import chain
 import json
 import os
 import urllib.request
 
 
-INPUT_FILE = "https://packagecontrol.io/channel_v3.json"
+v3_CHANNEL = "https://packagecontrol.io/channel_v3.json"
+v4_CHANNEL = "https://packagecontrol.github.io/channel/channel_v4.json"
 OUTPUT_FILE = os.path.abspath("channel.json")
 
 
 def main():
-    channel = http_get_json(INPUT_FILE)
+    v3_channel = http_get_json(v3_CHANNEL)
+    v4_channel = http_get_json(v4_CHANNEL)
+
+    dependencies = v3_channel.pop('dependencies_cache', {})
+    for library in chain(*dependencies.values()):
+        del library['load_order']
+        for release in library['releases']:
+            release['python_versions'] = ['3.3']
+
+    channel = {
+        "schema_version": "4.0.0",
+        "repositories": v4_channel["repositories"] + v3_channel["repositories"],
+        "packages_cache": v3_channel["packages_cache"] | v4_channel["packages_cache"],
+        "libraries_cache": dependencies | v4_channel["libraries_cache"],
+    }
+
     for key, value in channel.items():
         match key:
-            case "repositories": value.sort()
-            case "packages_cache" | "dependencies_cache":
+            case "packages_cache" | "libraries_cache":
                 for repo_url, packages in value.items():
                     packages.sort(key=lambda p: p["name"])
                     for p in packages:

--- a/scripts/generate_channel.py
+++ b/scripts/generate_channel.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+import os
+import urllib.request
+
+
+INPUT_FILE = "https://packagecontrol.io/channel_v3.json"
+OUTPUT_FILE = os.path.abspath("channel.json")
+
+
+def main():
+    channel = http_get_json(INPUT_FILE)
+    for key, value in channel.items():
+        match key:
+            case "repositories": value.sort()
+            case "packages_cache" | "dependencies_cache":
+                for repo_url, packages in value.items():
+                    packages.sort(key=lambda p: p["name"])
+                    for p in packages:
+                        if "releases" in p:
+                            p["releases"].sort(
+                                key=lambda r: (
+                                    r.get("date") or r.get("version"),
+                                    r.get("platforms"),
+                                    r.get("sublime_text")
+                                )
+                            )
+
+    with open(OUTPUT_FILE, "w") as f:
+        json.dump(channel, f)
+
+
+def http_get_json(location: str) -> dict:
+    json_string = http_get(location)
+    return json.loads(json_string)
+
+
+def http_get(location: str) -> str:
+    req = urllib.request.Request(
+        location,
+        headers={'User-Agent': 'Mozilla/5.0'}
+    )
+    with urllib.request.urlopen(req) as response:
+        return response.read().decode('utf-8')
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
To get hosting "for-free" and to enable ETag and Last-Modified support, cache the official "channel_v3.json" on GitHub.  Ensure to update the release asset only when the contents of the channel actually changed.

It is possible to post-process the "channel.json" in the `generate` phase, i.e. we could drop old ST2 only packages.  But that is not part of this PR.

DISCLAIMER:  This is only useful if our downloaders here actually support ETag/Last-Modified headers.  There is a "caching_downloader.py" but I actually don't know or checked if it is in use here.  

This was less work than one might expect as I just had a the yml action basically at hand with different URL's and names.  So I thought: why not share it?  Maybe it is useful and could solve a tiny problem we have here.  🥂  