### PR TITLE
Migrate default channel to packages.sublimetext.io

### DIFF
--- a/Package Control.sublime-settings
+++ b/Package Control.sublime-settings
@@ -3,14 +3,7 @@
 	// The repositories from these channels are placed in order after the
 	// repositories from the "repositories" setting
 	"channels": [
-		// channel_v4 for python 3.8 compatible libraries to enable plugins
-		// to migrate to python 3.8 until packagecontrol.io supports new scheme.
-		// Note: Must always be located before default channel in the list!
-		// Repo: https://github.com/packagecontrol/channel
-		"https://packagecontrol.github.io/channel/channel_v4.json",
-		// default channel for packages
-		// Repo: https://github.com/wbond/package_control_channel
-		"https://packagecontrol.io/channel_v3.json"
+		"https://packages.sublimetext.io/channel.json"
 	],
 
 	// A list of URLs that contain a packages JSON file or point to a

--- a/package_control/commands/discover_packages_command.py
+++ b/package_control/commands/discover_packages_command.py
@@ -9,4 +9,4 @@ class DiscoverPackagesCommand(sublime_plugin.ApplicationCommand):
     """
 
     def run(self):
-        sublime.run_command('open_url', {'url': 'https://packagecontrol.io/#discover'})
+        sublime.run_command('open_url', {'url': 'https://packages.sublimetext.io'})

--- a/package_control/download_manager.py
+++ b/package_control/download_manager.py
@@ -274,11 +274,6 @@ def update_url(url, debug):
     url = url.replace('://nodeload.github.com/', '://codeload.github.com/')
     url = re.sub(r'^(https://codeload\.github\.com/[^/#?]+/[^/#?]+/)zipball(/.*)$', '\\1zip\\2', url)
 
-    # Fix URLs from old versions of Package Control since we are going to
-    # remove all packages but Package Control from them to force upgrades
-    if url == 'https://sublime.wbond.net/repositories.json' or url == 'https://sublime.wbond.net/channel.json':
-        url = 'https://packagecontrol.io/channel_v3.json'
-
     if debug and url != original_url:
         console_write(
             '''

--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -49,9 +49,11 @@ from .settings import load_list_setting, pc_settings_filename, preferences_filen
 from .upgraders.git_upgrader import GitUpgrader
 from .upgraders.hg_upgrader import HgUpgrader
 
+DEFAULT_CHANNEL = 'https://packages.sublimetext.io/channel.json'
+DEFAULT_CHANNEL_ST3 = 'https://packages.sublimetext.io/channel_st3.json'
 
-DEFAULT_CHANNEL = 'https://packagecontrol.io/channel_v3.json'
 OLD_DEFAULT_CHANNELS = set([
+    'https://packagecontrol.io/channel_v3.json',
     'https://packagecontrol.io/channel.json',
     'https://sublime.wbond.net/channel.json',
     'https://sublime.wbond.net/repositories.json'
@@ -476,6 +478,7 @@ class PackageManager:
             A list of all available repositories
         """
 
+        is_st3 = int(sublime.version()) < 4000
         cache_ttl = self.settings.get('cache_length', 300)
         channels = self.settings.get('channels', [])
         # create copy to prevent backlash to settings object due to being extended
@@ -485,16 +488,14 @@ class PackageManager:
         found_default = False
         for channel in channels:
             channel = channel.strip()
-
-            if re.match(r'https?://([^.]+\.)*package-control\.io', channel):
-                console_write('Removed malicious channel %s' % channel)
-                continue
-
-            if channel in OLD_DEFAULT_CHANNELS:
+            if channel.lower() in OLD_DEFAULT_CHANNELS:
                 if found_default:
                     continue
                 found_default = True
                 channel = DEFAULT_CHANNEL
+
+            if is_st3 and channel.lower() == DEFAULT_CHANNEL:
+                channel = DEFAULT_CHANNEL_ST3
 
             # Caches various info from channels for performance
             cache_key = channel + '.repositories'


### PR DESCRIPTION
This commit replaces default channel pointing to packagecontrol.io by a new one from packages.sublimetext.io, effectively next step to sunset old site, which caused some trouble recently.