### PR TITLE
Fix public events API

### DIFF
--- a/package_control/bootstrap.py
+++ b/package_control/bootstrap.py
@@ -168,7 +168,6 @@ def _install_injectors():
 
         if hasattr(events, "__spec__"):
             events.__spec__.name = events.__name__
-            events.__spec__.origin = events.__package__
 
         sys.modules[events.__name__] = events
         del globals()["sys"]


### PR DESCRIPTION
Python 3.13 plugin_host of ST4201+ does no longer support `ZipLoader` in favor of PEP451 compliant approach.

This commit therefore refactors public `package_control` module to use only built-in import mechanisms, if possible and fallback to `ZipLoader` only, if a python 3.3 plugin needs to load `events` module from Package Control.sublime-package running on foreign python 3.8 or 3.13 host.

With this change behavior is equal on all plugin_hosts. Only `events` module is exported as this is the only module intended to be public.