### PR TITLE
Fix TypeError: set & tuple when .python-version is missing from archive

### DIFF
--- a/package_control/package_manager.py
+++ b/package_control/package_manager.py
@@ -1551,7 +1551,7 @@ class PackageManager:
                 python_versions = release.get("python_versions")
                 if python_versions:
                     python_version_raw = str(
-                        max(map(pep440.PEP440Version, set(python_versions) & supported_python_versions))
+                        max(map(pep440.PEP440Version, set(python_versions) & set(supported_python_versions)))
                     )
                     if python_version_raw:
                         python_version = python_version_raw


### PR DESCRIPTION
## Description

`sys_path.python_versions()` returns a **tuple**, but the fallback code in `install_package()` — triggered when a package archive contains no `.python-version` file — computes:

```python
max(map(pep440.PEP440Version, set(python_versions) & supported_python_versions))
```

where `supported_python_versions` is a tuple. `set & tuple` raises:

```
TypeError: unsupported operand type(s) for &: 'set' and 'tuple'
```

## Fix

Wrap `supported_python_versions` in `set()` so the intersection works:

```python
max(map(pep440.PEP440Version, set(python_versions) & set(supported_python_versions)))
```

## Impact

This bug blocks installation of any package from a third-party channel whose archives omit `.python-version` — the `KeyError` is caught, but the fallback immediately crashes with a `TypeError`.